### PR TITLE
Update dependency downloader

### DIFF
--- a/kernel-api/build.sbt
+++ b/kernel-api/build.sbt
@@ -49,10 +49,9 @@ libraryDependencies += "net.sf.jopt-simple" % "jopt-simple" % "4.6" // MIT
 //
 libraryDependencies ++= Seq(
   // Used to find and download jars from Maven-based repositories
-  "org.apache.ivy" % "ivy" % "2.4.0-rc1" // Apache v2,
-
-  // Used for multi class loader implementation
-//  "org.apache.openjpa" % "openjpa" % "2.4.0" // Apache v2
+  "org.apache.ivy" % "ivy" % "2.4.0-rc1", // Apache v2
+  "com.github.alexarchambault" %% "coursier" % "1.0.0-M6", // Apache v2
+  "com.github.alexarchambault" %% "coursier-cache" % "1.0.0-M6" // Apache v2
 )
 
 // Brought in in order to simplify the reading of each project's ivy.xml file

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -1,0 +1,234 @@
+package org.apache.toree.dependencies
+
+import java.io.{BufferedInputStream, File, PrintStream}
+import java.net.{URI, URL}
+import java.nio.file.Files
+
+import coursier.Dependency
+import coursier.core.Repository
+import coursier.ivy.{IvyXml, IvyRepository}
+import coursier.maven.{Pom, MavenRepository}
+import org.springframework.core.io.support.PathMatchingResourcePatternResolver
+
+import scalaz.\/
+import scalaz.concurrent.Task
+
+/**
+ * Represents a dependency downloader for jars that uses Coursier underneath.
+ */
+class CoursierDependencyDownloader extends DependencyDownloader {
+  @volatile private var repositories: Seq[Repository] = Nil
+  @volatile private var printStream: PrintStream = System.out
+  @volatile private var localDirectory: URI = null
+
+  // Initialization
+  setDownloadDirectory(DependencyDownloader.DefaultDownloadDirectory)
+  addMavenRepository(DependencyDownloader.DefaultMavenRepository)
+
+  /**
+   * Retrieves the dependency and all of its dependencies as jars.
+   *
+   * @param groupId The group id associated with the main dependency
+   * @param artifactId The id of the dependency artifact
+   * @param version The version of the main dependency
+   * @param transitive If true, downloads all dependencies of the specified
+   *                   dependency
+   * @param excludeBaseDependencies If true, will exclude any dependencies
+   *                                included in the build of the kernel
+   * @param ignoreResolutionErrors If true, ignores any errors on resolving
+   *                               dependencies and attempts to download all
+   *                               successfully-resolved dependencies
+   *
+   * @return The sequence of strings pointing to the retrieved dependency jars
+   */
+  override def retrieve(
+    groupId: String,
+    artifactId: String,
+    version: String,
+    transitive: Boolean,
+    excludeBaseDependencies: Boolean,
+    ignoreResolutionErrors: Boolean
+  ): Seq[URI] = {
+    assert(localDirectory != null)
+    import coursier._
+
+    // Grab exclusions using base dependencies
+    val exclusions: Set[(String, String)] = (if (excludeBaseDependencies) {
+      getBaseDependencies.map(_.module).map(m => (m.organization, m.name))
+    } else Nil).toSet
+
+    // Mark dependency that we want to download
+    val start = Resolution(Set(
+      Dependency(
+        module = Module(organization = groupId, name = artifactId),
+        version = version,
+        transitive = transitive,
+        exclusions = exclusions // NOTE: Source/Javadoc not downloaded by default
+      )
+    ))
+
+    printStream.println(s"Marking $groupId:$artifactId:$version for download")
+
+    lazy val defaultBase = new File(localDirectory).getAbsoluteFile
+
+    lazy val downloadLocations = Seq(
+      "file:" -> new File(defaultBase, "file"),
+      "http://" -> new File(defaultBase, "http"),
+      "https://" -> new File(defaultBase, "https")
+    )
+
+    // Build list of locations to fetch dependencies
+    val fetchLocations = Seq(ivy2Cache(localDirectory)) ++ repositories
+    val fetch = Fetch.from(fetchLocations, Cache.fetch(downloadLocations))
+
+    val fetchUris = localDirectory +: repositoriesToURIs(repositories)
+    printStream.println("Preparing to fetch from:")
+    printStream.println(s"-> ${fetchUris.mkString("\n-> ")}")
+
+    // Verify locations where we will download dependencies
+    val resolution = start.process.run(fetch).run
+
+    // Report any resolution errors
+    val errors: Seq[(Dependency, Seq[String])] = resolution.errors
+    errors.foreach { case (d, e) =>
+      printStream.println(s"-> Failed to resolve ${d.module.toString()}:${d.version}")
+      e.foreach(s => printStream.println(s"    -> $s"))
+    }
+
+    // If resolution errors, do not download
+    if (errors.nonEmpty && !ignoreResolutionErrors) return Nil
+
+    // Perform task of downloading dependencies
+    val localArtifacts: Seq[FileError \/ File] = Task.gatherUnordered(
+      resolution.artifacts.map(a => {
+        printStream.println(s"-> Downloading ${a.url}")
+        Cache.file(artifact = a, cache = downloadLocations).run
+      })
+    ).run
+
+    // Print any errors in retrieving dependencies
+    localArtifacts.flatMap(_.swap.toOption).map(_.message)
+      .foreach(printStream.println)
+
+    // Print success
+    val uris = localArtifacts.flatMap(_.toOption).map(_.toURI)
+    uris.map(_.getPath).foreach(p => printStream.println(s"-> New file at $p"))
+
+    uris
+  }
+
+  /**
+   * Adds the specified resolver url as an additional search option.
+   *
+   * @param url The string representation of the url
+   */
+  override def addMavenRepository(url: URL): Unit =
+    repositories :+= MavenRepository(url.toString)
+
+  /**
+   * Sets the printstream to log to.
+   *
+   * @param printStream The new print stream to use for output logging
+   */
+  override def setPrintStream(printStream: PrintStream): Unit =
+    this.printStream = printStream
+  /**
+   * Returns a list of all repositories used by the downloader.
+   *
+   * @return The list of repositories as URIs
+   */
+  def getRepositories: Seq[URI] = repositoriesToURIs(repositories)
+
+  /**
+   * Returns the current directory where dependencies will be downloaded.
+   *
+   * @return The directory as a string
+   */
+  override def getDownloadDirectory: String =
+    new File(localDirectory).getAbsolutePath
+
+  /**
+   * Sets the directory where all downloaded jars will be stored.
+   *
+   * @param directory The directory to use
+   *
+   * @return True if successfully set directory, otherwise false
+   */
+  override def setDownloadDirectory(directory: File): Boolean = {
+    val path = directory.getAbsolutePath
+    val cleanPath = if (path.endsWith("/")) path else path + "/"
+    val dir = new File(cleanPath)
+
+    if (!dir.isDirectory) return false
+    if (!dir.exists() && !dir.mkdirs()) return false
+
+    localDirectory = dir.toURI
+    true
+  }
+
+  /**
+   * Retrieves base dependencies used when building Toree modules.
+   *
+   * @return The collection of dependencies
+   */
+  private def getBaseDependencies: Seq[Dependency] = {
+    import coursier.core.compatibility.xmlParse
+
+    // Find all of the *ivy.xml files on the classpath.
+    val ivyFiles = new PathMatchingResourcePatternResolver().getResources(
+      "classpath*:**/*ivy.xml"
+    )
+    val streams = ivyFiles.map(_.getInputStream)
+    val contents = streams.map(scala.io.Source.fromInputStream).map(_.getLines())
+    val nodes = contents.map(c => xmlParse(c.mkString("\n")))
+
+    // Report any errors reading XML
+    nodes.flatMap(_.left.toOption).foreach(s => printStream.println(s"Error: $s"))
+
+    // Grab Ivy XML projects
+    val projects = nodes.flatMap(_.right.toOption).map(IvyXml.project)
+
+    // Report any errors parsing Ivy XML
+    projects.flatMap(_.swap.toOption).foreach(s => printStream.println(s"Error: $s"))
+
+    // Grab dependencies from projects
+    val dependencies = projects.flatMap(_.toOption).flatMap(_.dependencies.map(_._2))
+
+    // Return unique dependencies
+    dependencies.distinct
+  }
+
+  /**
+   * Converts the provide repositories to their URI representations.
+   *
+   * @param repositories The repositories to convert
+   *
+   * @return The resulting URIs
+   */
+  private def repositoriesToURIs(repositories: Seq[Repository]) = repositories.map {
+    case IvyRepository(pattern, _, _, _, _, _, _, _)  => pattern
+    case MavenRepository(root, _, _)                  => root
+  }.map(new URI(_))
+
+  /** Creates new Ivy2 local repository using base home URI. */
+  private def ivy2Local(ivy2HomeUri: URI) = IvyRepository(
+    ivy2HomeUri.toString + "local/" +
+      "[organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)" +
+      "[revision]/[type]s/[artifact](-[classifier]).[ext]"
+  )
+
+  /** Creates new Ivy2 cache repository using base home URI. */
+  private def ivy2Cache(ivy2HomeUri: URI) = IvyRepository(
+    ivy2HomeUri.toString + "cache/" +
+      "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/" +
+      "[type]s/[artifact]-[revision](-[classifier]).[ext]",
+    metadataPatternOpt = Some(
+      ivy2HomeUri + "cache/" +
+        "(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[organisation]/[module]/" +
+        "[type]-[revision](-[classifier]).[ext]"
+    ),
+    withChecksums = false,
+    withSignatures = false,
+    dropInfoAttributes = true
+  )
+}

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
@@ -17,11 +17,11 @@
 
 package org.apache.toree.dependencies
 
-import java.io.PrintStream
-import java.net.URL
+import java.io.{File, PrintStream}
+import java.net.{URI, URL}
+import java.nio.file.Files
 
-abstract class DependencyDownloader(repositoryUrl: String, baseDir: String) {
-
+abstract class DependencyDownloader {
   /**
    * Retrieves the dependency and all of its dependencies as jars.
    *
@@ -32,13 +32,21 @@ abstract class DependencyDownloader(repositoryUrl: String, baseDir: String) {
    *                   dependency
    * @param excludeBaseDependencies If true, will exclude any dependencies
    *                                included in the build of the kernel
+   * @param ignoreResolutionErrors If true, ignores any errors on resolving
+   *                               dependencies and attempts to download all
+   *                               successfully-resolved dependencies
    *
-   * @return The sequence of strings pointing to the retrieved dependency jars
+   * @return The sequence of URIs represented downloaded (even from cache)
+   *         dependencies
    */
   def retrieve(
-    groupId: String, artifactId: String, version: String,
-    transitive: Boolean = true, excludeBaseDependencies: Boolean = true
-  ): Seq[URL]
+    groupId: String,
+    artifactId: String,
+    version: String,
+    transitive: Boolean = true,
+    excludeBaseDependencies: Boolean = true,
+    ignoreResolutionErrors: Boolean = true
+  ): Seq[URI]
 
   /**
    * Sets the printstream to log to.
@@ -47,4 +55,42 @@ abstract class DependencyDownloader(repositoryUrl: String, baseDir: String) {
    */
   def setPrintStream(printStream: PrintStream): Unit
 
+  /**
+   * Adds the specified resolver url as an additional search option.
+   *
+   * @param url The url of the repository
+   */
+  def addMavenRepository(url: URL): Unit
+
+  /**
+   * Returns a list of all repositories used by the downloader.
+   *
+   * @return The list of repositories as URIs
+   */
+  def getRepositories: Seq[URI]
+
+  /**
+   * Sets the directory where all downloaded jars will be stored.
+   *
+   * @param directory The directory to use
+   *
+   * @return True if successfully set directory, otherwise false
+   */
+  def setDownloadDirectory(directory: File): Boolean
+
+  /**
+   * Returns the current directory where dependencies will be downloaded.
+   *
+   * @return The directory as a string
+   */
+  def getDownloadDirectory: String
+}
+
+object DependencyDownloader {
+  /** Default Maven repository to use with downloaders. */
+  val DefaultMavenRepository = new URL("https://repo1.maven.org/maven2")
+
+  /** Default download directory for dependencies. */
+  val DefaultDownloadDirectory =
+    Files.createTempDirectory("toree-dependency-downloads-").toFile
 }

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
@@ -35,6 +35,10 @@ abstract class DependencyDownloader {
    * @param ignoreResolutionErrors If true, ignores any errors on resolving
    *                               dependencies and attempts to download all
    *                               successfully-resolved dependencies
+   * @param extraRepositories Additional repositories to use only for this
+   *                          dependency
+   * @param verbose If true, prints out additional information
+   * @param trace If true, prints trace of download process
    *
    * @return The sequence of URIs represented downloaded (even from cache)
    *         dependencies
@@ -45,7 +49,10 @@ abstract class DependencyDownloader {
     version: String,
     transitive: Boolean = true,
     excludeBaseDependencies: Boolean = true,
-    ignoreResolutionErrors: Boolean = true
+    ignoreResolutionErrors: Boolean = true,
+    extraRepositories: Seq[URL] = Nil,
+    verbose: Boolean = false,
+    trace: Boolean = false
   ): Seq[URI]
 
   /**
@@ -61,6 +68,13 @@ abstract class DependencyDownloader {
    * @param url The url of the repository
    */
   def addMavenRepository(url: URL): Unit
+
+  /**
+   * Remove the specified resolver url from the search options.
+   *
+   * @param url The url of the repository
+   */
+  def removeMavenRepository(url: URL): Unit
 
   /**
    * Returns a list of all repositories used by the downloader.

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
@@ -87,8 +87,11 @@ class IvyDependencyDownloader(
     artifactId: String,
     version: String,
     transitive: Boolean = true,
-    excludeBaseDependencies: Boolean = true,
-    ignoreResolutionErrors: Boolean = true
+    excludeBaseDependencies: Boolean,
+    ignoreResolutionErrors: Boolean,
+    extraRepositories: Seq[URL],
+    verbose: Boolean,
+    trace: Boolean
   ): Seq[URI] = {
     // Start building the ivy.xml file
     val ivyFile = File.createTempFile("ivy-custom", ".xml")
@@ -195,6 +198,13 @@ class IvyDependencyDownloader(
    * @param url The url of the repository
    */
   override def addMavenRepository(url: URL): Unit = ???
+
+  /**
+   * Remove the specified resolver url from the search options.
+   *
+   * @param url The url of the repository
+   */
+  override def removeMavenRepository(url: URL): Unit = ???
 
   /**
    * Returns a list of all repositories used by the downloader.

--- a/kernel-api/src/main/scala/org/apache/toree/utils/ArgumentParsingSupport.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/utils/ArgumentParsingSupport.scala
@@ -56,4 +56,10 @@ trait ArgumentParsingSupport {
     require(options != null, "Arguments not parsed yet!")
     Some(options.valueOf(spec)).filter(_ != null)
   }
+
+  // NOTE: Cannot be implicit as conflicts with get
+  def getAll[T](spec: OptionSpec[T]): Option[List[T]] = {
+    require(options != null, "Arguments not parsed yet!")
+    Some(options.valuesOf(spec).asScala.toList).filter(_ != null)
+  }
 }

--- a/kernel-api/src/test/scala/org/apache/toree/dependencies/CoursierDependencyDownloaderSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/dependencies/CoursierDependencyDownloaderSpec.scala
@@ -1,0 +1,96 @@
+package org.apache.toree.dependencies
+
+import java.net.URL
+import java.nio.file.Files
+
+import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+
+class CoursierDependencyDownloaderSpec extends FunSpec with Matchers
+  with OneInstancePerTest
+{
+  private val coursierDependencyDownloader = new CoursierDependencyDownloader
+
+  describe("CoursierDependencyDownloader") {
+    describe("#addMavenRepository") {
+      it("should add to the list of repositories") {
+        val repo = new URL("http://some-repo.com")
+
+        coursierDependencyDownloader.addMavenRepository(repo)
+
+        val repos = coursierDependencyDownloader.getRepositories
+
+        repos should contain (repo.toURI)
+      }
+    }
+
+    describe("#removeMavenRepository") {
+      it("should remove from the list of repositories") {
+        val repo = new URL("http://some-repo.com")
+
+        coursierDependencyDownloader.addMavenRepository(repo)
+        coursierDependencyDownloader.removeMavenRepository(repo)
+
+        val repos = coursierDependencyDownloader.getRepositories
+
+        repos should not contain (repo.toURI)
+      }
+    }
+
+    describe("#setDownloadDirectory") {
+      it("should set the new download directory if valid") {
+        val validDir = Files.createTempDirectory("tmpdir").toFile
+        validDir.deleteOnExit()
+
+        val result = coursierDependencyDownloader.setDownloadDirectory(validDir)
+        result should be (true)
+
+        val dir = coursierDependencyDownloader.getDownloadDirectory
+        dir should be (validDir.getAbsolutePath)
+      }
+
+      it("should not change the directory if given a file") {
+        val invalidDir = Files.createTempFile("tmp", "file").toFile
+        invalidDir.deleteOnExit()
+
+        val result = coursierDependencyDownloader.setDownloadDirectory(invalidDir)
+        result should be (false)
+
+        val dir = coursierDependencyDownloader.getDownloadDirectory
+        dir should not be (invalidDir.getAbsolutePath)
+      }
+
+      it("should support creating missing directories") {
+        val baseDir = Files.createTempDirectory("tmpdir").toFile
+        val validDir = baseDir.toPath.resolve("otherdir").toFile
+        validDir.deleteOnExit()
+        baseDir.deleteOnExit()
+
+        val result = coursierDependencyDownloader.setDownloadDirectory(validDir)
+        result should be (true)
+
+        val dir = coursierDependencyDownloader.getDownloadDirectory
+        dir should be (validDir.getAbsolutePath)
+      }
+    }
+
+    describe("#getRepositories") {
+      it("should have the default repositories") {
+        val expected = Seq(DependencyDownloader.DefaultMavenRepository.toURI)
+
+        val actual = coursierDependencyDownloader.getRepositories
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#getDownloadDirectory") {
+      it("should have the default download directory") {
+        val expected = DependencyDownloader.DefaultDownloadDirectory.getAbsolutePath
+
+        val actual = coursierDependencyDownloader.getDownloadDirectory
+
+        actual should be (expected)
+      }
+    }
+  }
+}

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
@@ -17,12 +17,13 @@
 
 package org.apache.toree.boot.layer
 
+import java.io.File
 import java.util
 import java.util.concurrent.ConcurrentHashMap
 
 import akka.actor.ActorRef
 import org.apache.toree.comm.{CommManager, KernelCommManager, CommRegistrar, CommStorage}
-import org.apache.toree.dependencies.{DependencyDownloader, IvyDependencyDownloader}
+import org.apache.toree.dependencies.{CoursierDependencyDownloader, DependencyDownloader, IvyDependencyDownloader}
 import org.apache.toree.global
 import org.apache.toree.interpreter._
 import org.apache.toree.kernel.api.{KernelLike, Kernel}
@@ -122,8 +123,12 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
   private def initializeDependencyDownloader(config: Config) = {
-    val dependencyDownloader = new IvyDependencyDownloader(
+    /*val dependencyDownloader = new IvyDependencyDownloader(
       "http://repo1.maven.org/maven2/", config.getString("ivy_local")
+    )*/
+    val dependencyDownloader = new CoursierDependencyDownloader
+    dependencyDownloader.setDownloadDirectory(
+      new File(config.getString("ivy_local"))
     )
 
     dependencyDownloader

--- a/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
+++ b/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
@@ -30,8 +30,13 @@ class AddDeps extends LineMagic with IncludeInterpreter
 
   private lazy val printStream = new PrintStream(outputStream)
 
-  val _transitive =
-    parser.accepts("transitive", "retrieve dependencies recursively")
+  val _transitive = parser.accepts(
+    "transitive", "Retrieve dependencies recursively"
+  )
+
+  val _abortOnResolutionErrors = parser.accepts(
+    "abort-on-resolution-errors", "Abort (no downloads) when resolution fails"
+  )
 
   /**
    * Execute a magic representing a line magic.
@@ -42,11 +47,15 @@ class AddDeps extends LineMagic with IncludeInterpreter
     val nonOptionArgs = parseArgs(code)
     dependencyDownloader.setPrintStream(printStream)
 
-    // TODO: require a version or use the most recent if omitted?
     if (nonOptionArgs.size == 3) {
       // get the jars and hold onto the paths at which they reside
       val urls = dependencyDownloader.retrieve(
-        nonOptionArgs(0), nonOptionArgs(1), nonOptionArgs(2), _transitive)
+        groupId                 = nonOptionArgs.head,
+        artifactId              = nonOptionArgs(1),
+        version                 = nonOptionArgs(2),
+        transitive              = _transitive,
+        ignoreResolutionErrors  = !_abortOnResolutionErrors
+      ).map(_.toURL)
 
       // add the jars to the interpreter and spark context
       interpreter.addJars(urls:_*)

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/AddDepsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/AddDepsSpec.scala
@@ -18,7 +18,7 @@
 package org.apache.toree.magic.builtin
 
 import java.io.{ByteArrayOutputStream, OutputStream}
-import java.net.URL
+import java.net.{URI, URL}
 
 import org.apache.toree.dependencies.DependencyDownloader
 import org.apache.toree.interpreter.Interpreter
@@ -70,14 +70,18 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
         verify(mockIntp, times(0)).bind(any(), any(), any(), any())
         verify(mockSC, times(0)).addJar(any())
         verify(mockDownloader, times(0)).retrieve(
-          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean())
+          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
+          anyBoolean(), any[Seq[URL]], anyBoolean(), anyBoolean()
+        )
         actual should be (expected)
       }
 
       it("should set the retrievals transitive to true if provided") {
         val mockDependencyDownloader = mock[DependencyDownloader]
         doReturn(Nil).when(mockDependencyDownloader).retrieve(
-          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean())
+          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
+          anyBoolean(), any[Seq[URL]], anyBoolean(), anyBoolean()
+        )
 
         val addDepsMagic = new AddDeps
           with IncludeSparkContext
@@ -103,7 +107,9 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
       it("should set the retrieval's transitive to false if not provided") {
         val mockDependencyDownloader = mock[DependencyDownloader]
         doReturn(Nil).when(mockDependencyDownloader).retrieve(
-          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean())
+          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
+          anyBoolean(), any[Seq[URL]], anyBoolean(), anyBoolean()
+        )
 
         val addDepsMagic = new AddDeps
           with IncludeSparkContext
@@ -129,7 +135,9 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
       it("should add retrieved artifacts to the interpreter") {
         val mockDependencyDownloader = mock[DependencyDownloader]
         doReturn(Nil).when(mockDependencyDownloader).retrieve(
-          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean())
+          anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
+          anyBoolean(), any[Seq[URL]], anyBoolean(), anyBoolean()
+        )
         val mockInterpreter = mock[Interpreter]
 
         val addDepsMagic = new AddDeps
@@ -154,10 +162,11 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
 
       it("should add retrieved artifacts to the spark context") {
         val mockDependencyDownloader = mock[DependencyDownloader]
-        val fakeUrl = new URL("file:/foo")
-        doReturn(fakeUrl :: fakeUrl :: fakeUrl :: Nil)
+        val fakeUri = new URI("file:/foo")
+        doReturn(fakeUri :: fakeUri :: fakeUri :: Nil)
           .when(mockDependencyDownloader).retrieve(
-            anyString(), anyString(), anyString(), anyBoolean(), anyBoolean()
+            anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
+            anyBoolean(), any[Seq[URL]], anyBoolean(), anyBoolean()
           )
         val mockSparkContext = mock[SparkContext]
 


### PR DESCRIPTION
Adds the following options to %AddDeps:

- `--repository <URL>` to include another repository when downloading
- `--trace` to print out download information
- `--verbose` to print out miscellaneous information

```scala
%AddDeps org.apache.spark spark-streaming-mqtt_2.10 1.5.2 --trace --transitive --repository https://extra-repo.com
```

These options will show up in the help menu. You can provide `--repository` more than once to include more than one additional repository.

Will ignore any malformed URL. Will try repositories provided by `--repository` first before default repositories.