### PR TITLE
Added functions to send rich display content to client

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ dist/
 .example-image
 .ensime
 .ensime_cache/
+
+Untitled*.ipynb

--- a/kernel-api/src/main/scala/org/apache/toree/kernel/api/DisplayMethodsLike.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/kernel/api/DisplayMethodsLike.scala
@@ -1,0 +1,50 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package org.apache.toree.kernel.api
+
+/**
+ * Represents the methods available to display data of different mime-types from the kernel to the
+ * client.
+ */
+trait DisplayMethodsLike {
+
+  /**
+   * Send a display message of the specified mime-type and content
+   * @param mimeType The mime-type of the content (i.e. text/html)
+   * @param data The content to send for display
+   */
+  def content(mimeType: String, data: String): Unit
+
+  /**
+   * Send html content to the client
+   * @param data The content to send for display
+   */
+  def html(data: String): Unit = content("text/html", data)
+
+  /**
+   * Send javascript content to the client
+   * @param data The content to send for display
+   */
+  def javascript(data: String): Unit = content("application/javascript", data)
+
+  /**
+   * Sends a clear-output message to client
+   * @param wait if true, client waits for next display_data to clear
+   */
+  def clear(wait: Boolean = false): Unit
+}

--- a/kernel-api/src/main/scala/org/apache/toree/kernel/api/KernelLike.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/kernel/api/KernelLike.scala
@@ -60,6 +60,14 @@ trait KernelLike {
   def stream: StreamMethodsLike
 
   /**
+   * Returns a collection of methods that can be used to display data from the
+   * kernel to the client.
+   *
+   * @return The collection of display methods
+   */
+  def display: DisplayMethodsLike
+
+  /**
    * Returns a print stream to be used for communication back to clients
    * via standard out.
    *

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/HandlerInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/HandlerInitialization.scala
@@ -176,6 +176,8 @@ trait StandardHandlerInitialization extends HandlerInitialization {
 
     initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.ExecuteResult)
     initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.Stream)
+    initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.DisplayData)
+    initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.ClearOutput)
     initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.ExecuteInput)
     initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.Status)
     initializeSocketHandler(SocketType.IOPub, MessageType.Outgoing.Error)

--- a/kernel/src/main/scala/org/apache/toree/kernel/api/DisplayMethods.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/api/DisplayMethods.scala
@@ -1,0 +1,59 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package org.apache.toree.kernel.api
+
+import org.apache.toree.kernel.protocol.v5
+import org.apache.toree.kernel.protocol.v5.{KMBuilder, KernelMessage}
+import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
+
+/**
+ * Represents the methods available to send display content from the kernel to the
+ * client.
+ */
+class DisplayMethods(
+  private val actorLoader: ActorLoader,
+  private val parentMessage: KernelMessage,
+  private val kernelMessageBuilder: KMBuilder)
+
+  extends DisplayMethodsLike {
+
+  private[api] val kmBuilder = kernelMessageBuilder.withParent(parentMessage)
+
+  override def content(mimeType: String, data: String): Unit = {
+    val displayData = v5.content.DisplayData("user", Map(mimeType -> data), Map())
+
+    val kernelMessage = kmBuilder
+      .withIds(Seq(v5.content.DisplayData.toTypeString))
+      .withHeader(v5.content.DisplayData.toTypeString)
+      .withContentString(displayData).build
+
+    actorLoader.load(v5.SystemActorType.KernelMessageRelay) ! kernelMessage
+  }
+
+  override def clear(wait: Boolean = false): Unit = {
+    val clearOutput = v5.content.ClearOutput(wait)
+
+    val kernelMessage = kmBuilder
+      .withIds(Seq(v5.content.ClearOutput.toTypeString))
+      .withHeader(v5.content.ClearOutput.toTypeString)
+      .withContentString(clearOutput).build
+
+    actorLoader.load(v5.SystemActorType.KernelMessageRelay) ! kernelMessage
+
+  }
+}

--- a/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
@@ -185,6 +185,30 @@ class Kernel (
   }
 
   /**
+   * Returns a collection of methods that can be used to display data from the
+   * kernel to the client.
+   *
+   * @return The collection of display methods
+   */
+  override def display: DisplayMethodsLike = display()
+
+  /**
+   * Constructs a new instance of the stream methods using the specified
+   * kernel message instance.
+   *
+   * @param parentMessage The message to serve as the parent of outgoing
+   *                      messages sent as a result of using streaming methods
+   *
+   * @return The collection of streaming methods
+   */
+  private[toree] def display(
+    parentMessage: v5.KernelMessage = lastKernelMessage(),
+    kmBuilder: v5.KMBuilder = v5.KMBuilder()
+  ): DisplayMethods = {
+    new DisplayMethods(actorLoader, parentMessage, kmBuilder)
+  }
+
+  /**
    * Constructs a new instance of the factory methods using the latest
    * kernel message instance.
    *

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CommCloseHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CommCloseHandler.scala
@@ -18,6 +18,7 @@
 package org.apache.toree.kernel.protocol.v5.handler
 
 import org.apache.toree.comm.{KernelCommWriter, CommRegistrar, CommWriter, CommStorage}
+import org.apache.toree.global.ExecuteRequestState
 import org.apache.toree.kernel.protocol.v5.content.CommClose
 import org.apache.toree.kernel.protocol.v5.kernel.{Utilities, ActorLoader}
 import org.apache.toree.kernel.protocol.v5.{KMBuilder, KernelMessage}
@@ -43,6 +44,8 @@ class CommCloseHandler(
 {
   override def process(kernelMessage: KernelMessage): Future[_] = future {
     logKernelMessageAction("Initiating Comm Close for", kernelMessage)
+
+    ExecuteRequestState.processIncomingKernelMessage(kernelMessage)
 
     val kmBuilder = KMBuilder().withParent(kernelMessage)
 

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CommMsgHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CommMsgHandler.scala
@@ -18,6 +18,7 @@
 package org.apache.toree.kernel.protocol.v5.handler
 
 import org.apache.toree.comm.{KernelCommWriter, CommRegistrar, CommWriter, CommStorage}
+import org.apache.toree.global.ExecuteRequestState
 import org.apache.toree.kernel.protocol.v5.content.CommMsg
 import org.apache.toree.kernel.protocol.v5.kernel.{Utilities, ActorLoader}
 import org.apache.toree.kernel.protocol.v5.{KMBuilder, KernelMessage}
@@ -43,6 +44,8 @@ class CommMsgHandler(
 {
   override def process(kernelMessage: KernelMessage): Future[_] = future {
     logKernelMessageAction("Initiating Comm Msg for", kernelMessage)
+
+    ExecuteRequestState.processIncomingKernelMessage(kernelMessage)
 
     val kmBuilder = KMBuilder().withParent(kernelMessage)
 

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CommOpenHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CommOpenHandler.scala
@@ -18,6 +18,7 @@
 package org.apache.toree.kernel.protocol.v5.handler
 
 import org.apache.toree.comm.{KernelCommWriter, CommStorage, CommRegistrar, CommWriter}
+import org.apache.toree.global.ExecuteRequestState
 import org.apache.toree.kernel.protocol.v5.content.CommOpen
 import org.apache.toree.kernel.protocol.v5.kernel.{Utilities, ActorLoader}
 import org.apache.toree.kernel.protocol.v5.{KMBuilder, KernelMessage}
@@ -43,6 +44,8 @@ class CommOpenHandler(
 {
   override def process(kernelMessage: KernelMessage): Future[_] = future {
     logKernelMessageAction("Initiating Comm Open for", kernelMessage)
+
+    ExecuteRequestState.processIncomingKernelMessage(kernelMessage)
 
     val kmBuilder = KMBuilder().withParent(kernelMessage)
 

--- a/kernel/src/test/scala/org/apache/toree/kernel/api/DisplayMethodsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/api/DisplayMethodsSpec.scala
@@ -1,0 +1,160 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+
+package org.apache.toree.kernel.api
+
+import akka.actor.ActorSystem
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
+import org.apache.toree.kernel.protocol.v5
+import org.apache.toree.kernel.protocol.v5.KernelMessage
+import org.mockito.Mockito._
+import org.scalatest.mock.MockitoSugar
+import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import play.api.libs.json.Json
+
+import scala.concurrent.duration._
+
+class DisplayMethodsSpec extends TestKit(
+  ActorSystem("DisplayMethodsSpec")
+) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfter
+{
+  private val MaxDuration = 300.milliseconds
+
+  private var kernelMessageRelayProbe: TestProbe = _
+  private var mockParentHeader: v5.ParentHeader = _
+  private var mockActorLoader: v5.kernel.ActorLoader = _
+  private var mockKernelMessage: v5.KernelMessage = _
+  private var displayMethods: DisplayMethods = _
+
+  before {
+    kernelMessageRelayProbe = TestProbe()
+
+    mockParentHeader = mock[v5.ParentHeader]
+
+    mockActorLoader = mock[v5.kernel.ActorLoader]
+    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path))
+      .when(mockActorLoader).load(v5.SystemActorType.KernelMessageRelay)
+
+    mockKernelMessage = mock[v5.KernelMessage]
+    doReturn(mockParentHeader).when(mockKernelMessage).header
+
+    displayMethods = new DisplayMethods(mockActorLoader, mockKernelMessage, v5.KMBuilder())
+  }
+
+  describe("DisplayMethods") {
+    describe("#()") {
+      it("should put the header of the given message as the parent header") {
+        val expected = mockKernelMessage.header
+        val actual = displayMethods.kmBuilder.build.parentHeader
+
+        actual should be (expected)
+      }
+    }
+
+    describe("#content") {
+      it("should send a message containing all the contents and mimetype") {
+        val expectedContent = "some text"
+        val expectedMimeType = "some mime type"
+
+        displayMethods.content(expectedMimeType, expectedContent)
+
+        val outgoingMessage = kernelMessageRelayProbe.receiveOne(MaxDuration)
+        val kernelMessage = outgoingMessage.asInstanceOf[KernelMessage]
+
+        val actualDisplayData = Json.parse(kernelMessage.contentString)
+          .as[v5.content.DisplayData].data
+
+        actualDisplayData should contain (expectedMimeType -> expectedContent)
+      }
+    }
+
+    describe("#html") {
+      it("should send a message containing the contents and the html mimetype") {
+        val expectedContent = "some text"
+
+        displayMethods.html(expectedContent)
+
+        val outgoingMessage = kernelMessageRelayProbe.receiveOne(MaxDuration)
+        val kernelMessage = outgoingMessage.asInstanceOf[KernelMessage]
+
+        val actualDisplayData = Json.parse(kernelMessage.contentString)
+          .as[v5.content.DisplayData].data
+
+        actualDisplayData should contain ("text/html" -> expectedContent)
+      }
+    }
+
+    describe("#javascript") {
+      it("should send a message containing the contents and the javascript mimetype") {
+        val expectedContent = "some text"
+
+        displayMethods.javascript(expectedContent)
+
+        val outgoingMessage = kernelMessageRelayProbe.receiveOne(MaxDuration)
+        val kernelMessage = outgoingMessage.asInstanceOf[KernelMessage]
+
+        val actualDisplayData = Json.parse(kernelMessage.contentString)
+          .as[v5.content.DisplayData].data
+
+        actualDisplayData should contain ("application/javascript" -> expectedContent)
+      }
+    }
+
+    describe("#clear") {
+      it("should send a clear-output message with wait false when no args passed") {
+
+        displayMethods.clear()
+
+        val outgoingMessage = kernelMessageRelayProbe.receiveOne(MaxDuration)
+        val kernelMessage = outgoingMessage.asInstanceOf[KernelMessage]
+
+        val actualClearOutput = Json.parse(kernelMessage.contentString)
+          .as[v5.content.ClearOutput]
+
+        actualClearOutput._wait should be (false)
+      }
+
+      it("should send a clear-output message with wait false when false passed") {
+
+        displayMethods.clear(false)
+
+        val outgoingMessage = kernelMessageRelayProbe.receiveOne(MaxDuration)
+        val kernelMessage = outgoingMessage.asInstanceOf[KernelMessage]
+
+        val actualClearOutput = Json.parse(kernelMessage.contentString)
+          .as[v5.content.ClearOutput]
+
+        actualClearOutput._wait should be (false)
+      }
+
+      it("should send a clear-output message with wait true when true passed") {
+
+        displayMethods.clear(true)
+
+        val outgoingMessage = kernelMessageRelayProbe.receiveOne(MaxDuration)
+        val kernelMessage = outgoingMessage.asInstanceOf[KernelMessage]
+
+        val actualClearOutput = Json.parse(kernelMessage.contentString)
+          .as[v5.content.ClearOutput]
+
+        actualClearOutput._wait should be (true)
+      }
+    }
+  }
+
+}

--- a/kernel/src/test/scala/org/apache/toree/kernel/api/KernelSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/api/KernelSpec.scala
@@ -176,6 +176,23 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
       }
     }
 
+    describe("#display") {
+      it("should throw an exception if the ExecuteRequestState has not been set") {
+        intercept[IllegalArgumentException] {
+          kernel.display
+        }
+      }
+
+      it("should create a DisplayMethods instance if the ExecuteRequestState has been set") {
+        ExecuteRequestState.processIncomingKernelMessage(
+          new KernelMessage(Nil, "", mock[Header], mock[ParentHeader],
+            mock[Metadata], "")
+        )
+
+        kernel.display shouldBe a [DisplayMethods]
+      }
+    }
+
     describe("when spark.master is set in config") {
 
       it("should create SparkConf") {


### PR DESCRIPTION
This PR adds a couple of functions to the `kernel` object to enable sending rich content to the client. For now it is supporting HTML and Javascript, but also has a generic method to send content of any mime-type that the client can handle.