### PR TITLE
Updated to use coursier for dependency resolution/downloading

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: scala
 scala:
     - "2.10.4"
-
+env:
+    global:
+        - COURSIER_NO_TERM=1
+        - TOREE_RESOLUTION_VERBOSITY=0
 jdk:
     - oraclejdk7
     - openjdk7
@@ -15,7 +18,9 @@ cache:
     directories:
         - $HOME/.ivy2/cache
         - $HOME/.sbt/boot/
+        - $HOME/.coursier/cache/v1
 
 branches:
     only:
         - master
+

--- a/kernel-api/build.sbt
+++ b/kernel-api/build.sbt
@@ -50,8 +50,8 @@ libraryDependencies += "net.sf.jopt-simple" % "jopt-simple" % "4.6" // MIT
 libraryDependencies ++= Seq(
   // Used to find and download jars from Maven-based repositories
   "org.apache.ivy" % "ivy" % "2.4.0-rc1", // Apache v2
-  "com.github.alexarchambault" %% "coursier" % "1.0.0-M6", // Apache v2
-  "com.github.alexarchambault" %% "coursier-cache" % "1.0.0-M6" // Apache v2
+  "com.github.alexarchambault" %% "coursier" % "1.0.0-M9", // Apache v2
+  "com.github.alexarchambault" %% "coursier-cache" % "1.0.0-M9" // Apache v2
 )
 
 // Brought in in order to simplify the reading of each project's ivy.xml file

--- a/project/Common.scala
+++ b/project/Common.scala
@@ -18,8 +18,9 @@
 import org.apache.commons.io.FileUtils
 import sbt._
 import Keys._
+import coursier.Keys._
 
-import scala.util.Properties
+import scala.util.{Try, Properties}
 
 object Common {
   //  Parameters for publishing to artifact repositories
@@ -50,6 +51,10 @@ object Common {
     "org.scalatest" %% "scalatest" % "2.2.0" % "test", // Apache v2
     "org.scalactic" %% "scalactic" % "2.2.0" % "test", // Apache v2
     "org.mockito" % "mockito-all" % "1.9.5" % "test"   // MIT
+  )
+
+  private val buildResolvers = Seq(
+    "Typesafe repository" at "http://repo.typesafe.com/typesafe/releases/"
   )
 
   // The prefix used for our custom artifact names
@@ -83,6 +88,18 @@ object Common {
     scalaVersion := buildScalaVersion,
     libraryDependencies ++= buildLibraryDependencies,
     isSnapshot := snapshot,
+    resolvers ++= buildResolvers,
+    coursierVerbosity := {
+      val level = Try(Integer.valueOf(Properties.envOrElse(
+        "TOREE_RESOLUTION_VERBOSITY", "1")
+      ).toInt).getOrElse(1)
+
+      scala.Console.out.println(
+        s"[INFO] Toree Resolution Verbosity Level = $level"
+      )
+
+      level
+    },
 
     scalacOptions in (Compile, doc) ++= Seq(
       // Ignore packages (for Scaladoc) not from our project

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -49,3 +49,5 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 // Provides auto-generating and publishing a gh-pages site
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 
+// Provides alternative resolving/downloading over sbt
+addSbtPlugin("com.github.alexarchambault" % "coursier-sbt-plugin" % "1.0.0-M9")


### PR DESCRIPTION
Switches dependency resolution/downloading from sbt's default to coursier (what we use for %AddDeps). Much faster, can run in parallel, can work offline using cache (sbt fails often if not online), more easily sandbox dependencies between projects, no global locks (waiting on ~/.ivy2/.sbt.ivy.lock), blah blah blah.