### PR TITLE
[TOREE-282] Remove `Created by` comments from source code

### DIFF
--- a/kernel/src/test/scala/test/utils/SparkContextProvider.scala
+++ b/kernel/src/test/scala/test/utils/SparkContextProvider.scala
@@ -18,9 +18,6 @@ package test.utils
 
 import org.apache.spark.{SparkConf, SparkContext}
 
-/**
- * Created by spark on 2/24/15.
- */
 object SparkContextProvider {
 
 

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplySpec.scala
@@ -21,9 +21,6 @@ import org.scalatest.{Matchers, FunSpec}
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsPath, JsValue, Json}
 
-/**
- * Created by Senkwich on 7/24/14.
- */
 class CompleteReplySpec extends FunSpec with Matchers {
 
 

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ConnectReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ConnectReplySpec.scala
@@ -21,9 +21,6 @@ import org.scalatest.{FunSpec, Matchers}
 import play.api.data.validation.ValidationError
 import play.api.libs.json.{JsPath, JsValue, Json}
 
-/**
- * Created by Senkwich on 7/24/14.
- */
 class ConnectReplySpec extends FunSpec with Matchers {
 
 


### PR DESCRIPTION
ASF strongly recommends to remove @author tags and `created by` because they imply individual ownership. We had better remove them if possible.