### PR TITLE
[TOREE 297]: Added options during install and runtime

### DIFF
--- a/etc/bin/run.sh
+++ b/etc/bin/run.sh
@@ -37,5 +37,10 @@ then
    SPARK_OPTS=${__TOREE_SPARK_OPTS__}
 fi
 
+if [ "${TOREE_OPTS}" = "" ]
+then
+   TOREE_OPTS=${__TOREE_OPTS__}
+fi
+
 SPARK_OPTS="--driver-class-path=\"${TOREE_ASSEMBLY}\" ${SPARK_OPTS}"
-eval exec "${SPARK_HOME}/bin/spark-submit" "${SPARK_OPTS}" --class org.apache.toree.Main "${TOREE_ASSEMBLY}" "$@"
+eval exec "${SPARK_HOME}/bin/spark-submit" "${SPARK_OPTS}" --class org.apache.toree.Main "${TOREE_ASSEMBLY}" "${TOREE_OPTS}" "$@"

--- a/etc/pip_install/toree/toreeapp.py
+++ b/etc/pip_install/toree/toreeapp.py
@@ -37,6 +37,7 @@ INTERPRETER_LANGUAGES = {
 PYTHON_PATH = 'PYTHONPATH'
 SPARK_HOME ='SPARK_HOME'
 TOREE_SPARK_OPTS = '__TOREE_SPARK_OPTS__'
+TOREE_OPTS = '__TOREE_OPTS__'
 DEFAULT_INTERPRETER = 'DEFAULT_INTERPRETER'
 
 class ToreeInstall(InstallKernelSpec):
@@ -48,6 +49,7 @@ class ToreeInstall(InstallKernelSpec):
     jupyter toree install --spark_home=/spark/home/dir
     jupyter toree install --spark_opts='--master=local[4]'
     jupyter toree install --kernel_name=toree_special
+    jupyter toree install --toree_opts='--nosparkcontext'
     jupyter toree install --interpreters=PySpark,SQL
     '''
 
@@ -60,12 +62,16 @@ class ToreeInstall(InstallKernelSpec):
     interpreters = Unicode('Scala', config=True,
         help='A comma separated list of the interpreters to install. The names of the interpreters are case sensitive.'
     )
+    toree_opts = Unicode('', config=True,
+        help='''Specify command line arguments for Apache Toree.'''
+    )
     spark_opts = Unicode('', config=True,
         help='''Specify command line arguments to proxy for spark config.'''
     )
     aliases = {
         'kernel_name': 'ToreeInstall.kernel_name',
         'spark_home': 'ToreeInstall.spark_home',
+        'toree_opts': 'ToreeInstall.toree_opts',
         'spark_opts': 'ToreeInstall.spark_opts',
         'interpreters' : 'ToreeInstall.interpreters'
     }
@@ -92,6 +98,7 @@ class ToreeInstall(InstallKernelSpec):
             # The SPARK_OPTS values are stored in TOREE_SPARK_OPTS to allow the two values to be merged when kernels
             # are run. This allows values to be specified during install, but also during runtime.
             TOREE_SPARK_OPTS : self.spark_opts,
+            TOREE_OPTS : self.toree_opts,
             SPARK_HOME : self.spark_home,
             PYTHON_PATH : '{0}/python:{0}/python/lib/{1}'.format(self.spark_home, py4j_zip)
         }


### PR DESCRIPTION
pip install now has --toree_opts for definig options during install time
run.sh overwrites --toree_opts if the environment variable TOREE_OPTS is defined