### PR TITLE
Updated kernel message relay to ignore unknown incoming and output messages

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/relay/KernelMessageRelay.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/relay/KernelMessageRelay.scala
@@ -26,9 +26,10 @@ import org.apache.toree.kernel.protocol.v5.content.ShutdownRequest
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.kernel.protocol.v5.{KernelMessage, MessageType, _}
 import org.apache.toree.utils.MessageLogSupport
+
 import scala.collection.immutable.HashMap
 import scala.concurrent.duration._
-import scala.util.{Random, Failure, Success}
+import scala.util.{Failure, Random, Success, Try}
 
 /**
  * This class is meant to be a relay for send KernelMessages through kernel
@@ -79,7 +80,11 @@ case class KernelMessageRelay(
       messageTypeString = incomingSpecialCases(messageTypeString)
     }
 
-    relay(MessageType.withName(messageTypeString), kernelMessage)
+    Try(MessageType.withName(messageTypeString)) match {
+      case Success(messageName) => relay(messageName, kernelMessage)
+      case Failure(_)           =>
+        logger.warn(s"Ignoring unknown message type: $messageTypeString")
+    }
   }
 
   private def outgoingRelay(kernelMessage: KernelMessage) = {
@@ -91,7 +96,11 @@ case class KernelMessageRelay(
       messageTypeString = outgoingSpecialCases(messageTypeString)
     }
 
-    relay(MessageType.withName(messageTypeString), kernelMessage)
+    Try(MessageType.withName(messageTypeString)) match {
+      case Success(messageName) => relay(messageName, kernelMessage)
+      case Failure(_)           =>
+        logger.warn(s"Ignoring unknown message type: $messageTypeString")
+    }
   }
 
 


### PR DESCRIPTION
Resolves [TOREE-272](https://issues.apache.org/jira/browse/TOREE-272) in terms of the kernel freezing on unknown message types.

Tested using `jupyter notebook` and `jupyter console` with Jupyter 4.2.0. Before the fix, an exception would be thrown and the kernel would halt. Now, a warning is printed that the message of type "..." will be ignored.

/cc @lbustelo 