### PR TITLE
[MINOR] Remove empty lines before Apache lincense header.

### DIFF
--- a/client/src/test/scala/org/apache/toree/comm/ClientCommWriterSpec.scala
+++ b/client/src/test/scala/org/apache/toree/comm/ClientCommWriterSpec.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/kernel/src/test/scala/org/apache/toree/comm/KernelCommWriterSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/comm/KernelCommWriterSpec.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/kernel/src/test/scala/test/utils/package.scala
+++ b/kernel/src/test/scala/test/utils/package.scala
@@ -14,6 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License
  */
+
 package test
 
 import scala.concurrent.duration._

--- a/macros/src/main/scala/org/apache/toree/annotations/Experimental.scala
+++ b/macros/src/main/scala/org/apache/toree/annotations/Experimental.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/macros/src/main/scala/org/apache/toree/annotations/Internal.scala
+++ b/macros/src/main/scala/org/apache/toree/annotations/Internal.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/protocol/src/main/scala/org/apache/toree/comm/CommCallbacks.scala
+++ b/protocol/src/main/scala/org/apache/toree/comm/CommCallbacks.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/protocol/src/main/scala/org/apache/toree/comm/CommRegistrar.scala
+++ b/protocol/src/main/scala/org/apache/toree/comm/CommRegistrar.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/protocol/src/main/scala/org/apache/toree/comm/CommWriter.scala
+++ b/protocol/src/main/scala/org/apache/toree/comm/CommWriter.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/content/CommContent.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/content/CommContent.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with

--- a/protocol/src/test/scala/org/apache/toree/comm/CommWriterSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/comm/CommWriterSpec.scala
@@ -1,4 +1,3 @@
-
 /*
  *  Licensed to the Apache Software Foundation (ASF) under one or more
  *  contributor license agreements.  See the NOTICE file distributed with


### PR DESCRIPTION
This PR aims to pass the RAT checking. Currently, it fails like the following.

```
$ etc/tools/check-licenses
Could not find Apache license headers in the following files:
 !????? /Users/dongjoon/toree/kernel/src/test/scala/test/utils/package.scala
```

After this PR, that will be.
```
$ etc/tools/check-licenses
RAT checks passed.
```