### PR TITLE
Remove the need to add assembly to driver-class-path

### DIFF
--- a/etc/bin/run.sh
+++ b/etc/bin/run.sh
@@ -42,5 +42,4 @@ then
    TOREE_OPTS=${__TOREE_OPTS__}
 fi
 
-SPARK_OPTS="--driver-class-path=\"${TOREE_ASSEMBLY}\" ${SPARK_OPTS}"
 eval exec "${SPARK_HOME}/bin/spark-submit" "${SPARK_OPTS}" --class org.apache.toree.Main "${TOREE_ASSEMBLY}" "${TOREE_OPTS}" "$@"

--- a/plugins/src/main/scala/org/apache/toree/plugins/PluginSearcher.scala
+++ b/plugins/src/main/scala/org/apache/toree/plugins/PluginSearcher.scala
@@ -101,10 +101,12 @@ class PluginSearcher {
       .filter(c => classMatches(Seq(c)))
   }
 
-  private def classpath = System.getProperty("java.class.path")
-    .split(File.pathSeparator)
-    .map(s => if (s.trim.length == 0) "." else s)
-    .map(new File(_))
-    .filter(_.getAbsolutePath.toLowerCase.contains("toree"))
-    .toList
+  private def classpath = {
+    new File(this.getClass.getProtectionDomain.getCodeSource.getLocation.getPath) :: System.getProperty("java.class.path")
+     .split(File.pathSeparator)
+     .map(s => if (s.trim.length == 0) "." else s)
+     .map(new File(_))
+     .filter(_.getAbsolutePath.toLowerCase.contains("toree"))
+     .toList
+  }
 }


### PR DESCRIPTION
This PR removes the need to have the assembly jar explicitly in the driver classpath. Now the `--driver-class-path` option is free for clients to use when installing Toree. It can be set through the `SPARK_OPTS`.