### PR TITLE
Make add deps installation directory either a specified path or a unique temp path per toree process.

### DIFF
--- a/etc/examples/notebooks/magic-tutorial.ipynb
+++ b/etc/examples/notebooks/magic-tutorial.ipynb
@@ -443,7 +443,7 @@
      "text": [
       "Marking org.joda:joda-money:0.11 for download\n",
       "Preparing to fetch from:\n",
-      "-> file:/tmp/.ivy2/\n",
+      "-> file:/tmp/toree_add_deps5662724810625125387/\n",
       "-> https://repo1.maven.org/maven2\n",
       "=> 1 (): Downloading https://repo1.maven.org/maven2/org/joda/joda-money/0.11/joda-money-0.11.pom.sha1\n",
       "=> 1 (): Downloading https://repo1.maven.org/maven2/org/joda/joda-money/0.11/joda-money-0.11.pom\n",
@@ -465,7 +465,7 @@
       "===> 2 (joda-money-0.11.jar): Downloaded 48481 bytes (76.08%)\n",
       "===> 2 (joda-money-0.11.jar): Downloaded 63725 bytes (100.00%)\n",
       "=> 2 (joda-money-0.11.jar): Finished downloading\n",
-      "-> New file at /tmp/.ivy2/https/repo1.maven.org/maven2/org/joda/joda-money/0.11/joda-money-0.11.jar\n"
+      "-> New file at /tmp/toree_add_deps5662724810625125387/https/repo1.maven.org/maven2/org/joda/joda-money/0.11/joda-money-0.11.jar\n"
      ]
     }
    ],
@@ -783,9 +783,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Toree - Scala",
-   "language": "scala",
-   "name": "toree_scala"
+   "display_name": "Toree",
+   "language": "",
+   "name": "toree"
   },
   "language_info": {
    "name": "scala"

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
@@ -18,6 +18,7 @@
 package org.apache.toree.boot.layer
 
 import java.io.File
+import java.nio.file.{Paths, Files}
 import java.util.concurrent.ConcurrentHashMap
 
 import akka.actor.ActorRef
@@ -116,12 +117,17 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
   private def initializeDependencyDownloader(config: Config) = {
-    /*val dependencyDownloader = new IvyDependencyDownloader(
-      "http://repo1.maven.org/maven2/", config.getString("ivy_local")
-    )*/
+    val depsDir = {
+      if(config.hasPath("deps_dir") && Files.exists(Paths.get(config.getString("deps_dir")))) {
+        config.getString("deps_dir")
+      } else {
+        Files.createTempDirectory("toree_add_deps").toFile.getAbsolutePath
+      }
+    }
+
     val dependencyDownloader = new CoursierDependencyDownloader
     dependencyDownloader.setDownloadDirectory(
-      new File(config.getString("ivy_local"))
+      new File(depsDir)
     )
 
     dependencyDownloader

--- a/kernel/src/main/scala/org/apache/toree/magic/builtin/AddJar.scala
+++ b/kernel/src/main/scala/org/apache/toree/magic/builtin/AddJar.scala
@@ -37,7 +37,7 @@ object AddJar {
         if(config.hasPath("jar_dir") && Files.exists(Paths.get(config.getString("jar_dir")))) {
           config.getString("jar_dir")
         } else {
-          Files.createTempDirectory("spark_kernel_add_jars").toFile.getAbsolutePath
+          Files.createTempDirectory("toree_add_jars").toFile.getAbsolutePath
         }
       )
       jarDir.get

--- a/resources/compile/reference.conf
+++ b/resources/compile/reference.conf
@@ -37,9 +37,6 @@ transport = "tcp"
 signature_scheme = "hmac-sha256"
 key = ""
 
-ivy_local = "/tmp/.ivy2"
-ivy_local = ${?IVY_LOCAL}
-
 interpreter_args = []
 
 magic_urls = []
@@ -52,6 +49,8 @@ send_empty_output = false
 send_empty_output = ${?SEND_EMPTY_OUTPUT}
 
 jar_dir = ${?JAR_DIR}
+
+deps_dir = ${?DEPS_DIR}
 
 default_interpreter = "Scala"
 default_interpreter = ${?DEFAULT_INTERPRETER}

--- a/resources/test/reference.conf
+++ b/resources/test/reference.conf
@@ -38,8 +38,7 @@ signature_scheme = "hmac-sha256"
 key = ""
 spark.master = "local[*]"
 
-ivy_local = "/tmp/.ivy2"
-ivy_local = ${?IVY_LOCAL}
+deps_dir = ${?DEPS_DIR}
 
 interpreter_args = []
 


### PR DESCRIPTION
Similarly to the logic of add jar this will:
* Allow the user to specify the dependency dir and use that if it exists, else will create a temp dir for that toree process.
* Update the magic-tutorial notebook to reflect the download dir location in the output.