### PR TITLE
Fix kernel info spec message structure due to spec changes.

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
@@ -18,6 +18,8 @@
 package org.apache.toree.boot
 
 import akka.actor.{ActorRef, ActorSystem}
+import com.typesafe.config.Config
+import org.apache.spark.SparkContext
 import org.apache.toree.boot.layer._
 import org.apache.toree.interpreter.Interpreter
 import org.apache.toree.kernel.api.Kernel
@@ -26,8 +28,6 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.security.KernelSecurityManager
 import org.apache.toree.utils.LogLike
-import com.typesafe.config.Config
-import org.apache.spark.SparkContext
 import org.zeromq.ZMQ
 
 import scala.util.Try
@@ -167,7 +167,7 @@ class KernelBootstrap(config: Config) extends LogLike {
 
   @inline private def displayVersionInfo() = {
     logger.info("Kernel version: " + SparkKernelInfo.implementationVersion)
-    logger.info("Scala version: " + SparkKernelInfo.languageVersion)
+    logger.info("Scala version: " + SparkKernelInfo.language_info.get("version"))
     logger.info("ZeroMQ (JeroMQ) version: " + ZMQ.getVersionString)
   }
 }

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/KernelInfoRequestHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/KernelInfoRequestHandler.scala
@@ -21,7 +21,6 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content.KernelInfoReply
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.utils.LogLike
-import play.api.libs.json.Json
 
 import scala.concurrent._
 
@@ -43,7 +42,6 @@ class KernelInfoRequestHandler(actorLoader: ActorLoader)
         kernelInfo.implementation,
         kernelInfo.implementationVersion,
         kernelInfo.language_info,
-        kernelInfo.languageVersion,
         kernelInfo.banner
       )
 

--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
@@ -38,12 +38,7 @@ object SparkKernelInfo {
   /**
    * Represents the language supported by the kernel.
    */
-  val language_info           = Map("name" -> "scala")
-
-  /**
-   * Represents the language version supported by the kernel.
-   */
-  val languageVersion         = BuildInfo.scalaVersion
+  val language_info           = Map("name" -> "scala", "version" -> BuildInfo.scalaVersion)
 
   /**
    * Represents the displayed name of the kernel.

--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoReply.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoReply.scala
@@ -25,7 +25,6 @@ case class KernelInfoReply (
   implementation: String,
   implementation_version: String,
   language_info: Map[String, String],
-  language_version: String,
   banner: String
 ) extends KernelMessageContent {
   override def content: String =

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoReplySpec.scala
@@ -27,14 +27,13 @@ class KernelInfoReplySpec extends FunSpec with Matchers {
     "protocol_version": "x.y.z",
     "implementation": "<name>",
     "implementation_version": "z.y.x",
-    "language_info": { "name": "<some language>" },
-    "language_version": "a.b.c",
+    "language_info": { "name": "<some language>", "version": "a.b.c" },
     "banner": "<some banner>"
   }
   """)
 
   val kernelInfoReply: KernelInfoReply = KernelInfoReply(
-    "x.y.z", "<name>", "z.y.x", Map("name" -> "<some language>"), "a.b.c", "<some banner>"
+    "x.y.z", "<name>", "z.y.x", Map("name" -> "<some language>", "version" -> "a.b.c"), "<some banner>"
   )
 
   describe("KernelInfoReply") {


### PR DESCRIPTION
When working on [Migrate System Tests To Use Jupyter Kernel Test](https://issues.apache.org/jira/browse/TOREE-296?jql=project%20%3D%20TOREE) it was discovered that the [kernel info spec](http://jupyter-client.readthedocs.io/en/latest/messaging.html#kernel-info) changed.  
These changes are needed to make the Jupyter tests pass.