### PR TITLE
Add jar kernel test and override execute_helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,9 +182,10 @@ system-test: pip-release
 		--name jupyter_kernel_tests \
 		-v `pwd`/dist/toree-pip:/srv/toree-pip \
 		-v `pwd`/test_toree.py:/srv/test_toree.py \
+		-v `pwd`/scala-interpreter/src/test/resources:/srv/system-test-resources \
 		$(IMAGE) \
-		bash -c "pip install /srv/toree-pip/toree*.tar.gz ; jupyter toree install --user --kernel_name='Apache_Toree' ; \
-		pip install nose jupyter_kernel_test ; python /srv/test_toree.py"
+		bash -c "(cd /srv/system-test-resources && python -m http.server 8000 &) && pip install /srv/toree-pip/toree*.tar.gz && jupyter toree install --user --kernel_name='Apache_Toree' && \
+		pip install nose jupyter_kernel_test && python /srv/test_toree.py"
 
 ################################################################################
 # Jars


### PR DESCRIPTION
[TOREE 317](https://issues.apache.org/jira/browse/TOREE-317?jql=project%20%3D%20TOREE)
* Overrides execute_helper to allow handling multiline code/streaming output that could exist in an add jar type operation.
* Includes sample custom test other than what is built it in.
* Tests addjar by volume mounting the resource/file.