### PR TITLE
Fix pyspark interpreter to handle execute results and output streams correctly.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,7 +118,7 @@ dev: .example-image dist
 
 test: VM_WORKDIR=/src/toree-kernel
 test:
-	$(call RUN,$(ENV_OPTS) sbt compile test)
+	$(call RUN,$(ENV_OPTS) JAVA_OPTS="-Xmx4096M" sbt compile test)
 
 sbt-%:
 	$(call RUN,$(ENV_OPTS) sbt $(subst sbt-,,$@) )
@@ -183,8 +183,10 @@ system-test: pip-release
 		-v `pwd`/dist/toree-pip:/srv/toree-pip \
 		-v `pwd`/test_toree.py:/srv/test_toree.py \
 		-v `pwd`/scala-interpreter/src/test/resources:/srv/system-test-resources \
+		--user=root \
 		$(IMAGE) \
-		bash -c "(cd /srv/system-test-resources && python -m http.server 8000 &) && pip install /srv/toree-pip/toree*.tar.gz && jupyter toree install --user --kernel_name='Apache_Toree' && \
+		bash -c "(cd /srv/system-test-resources && python -m http.server 8000 &) && \
+		pip install /srv/toree-pip/toree*.tar.gz && jupyter toree install --interpreters=PySpark,Scala && \
 		pip install nose jupyter_kernel_test && python /srv/test_toree.py"
 
 ################################################################################

--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/Interpreter.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/Interpreter.scala
@@ -20,8 +20,6 @@ package org.apache.toree.interpreter
 import java.net.URL
 
 import org.apache.toree.kernel.api.KernelLike
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.SQLContext
 
 import scala.tools.nsc.interpreter._
 
@@ -65,7 +63,7 @@ trait Interpreter {
    * @return The success/failure of the interpretation and the output from the
    *         execution or the failure
    */
-  def interpret(code: String, silent: Boolean = false):
+  def interpret(code: String, silent: Boolean = false, outputStreamResult: Option[OutputStream] = None):
     (Results.Result, Either[ExecuteOutput, ExecuteFailure])
 
   /**

--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerService.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerService.scala
@@ -18,7 +18,9 @@
 package org.apache.toree.interpreter.broker
 
 import org.apache.toree.interpreter.broker.BrokerTypes.{Code, CodeResults}
+
 import scala.concurrent.Future
+import scala.tools.nsc.interpreter._
 
 /**
  * Represents the service that provides the high-level interface between the
@@ -42,7 +44,7 @@ trait BrokerService {
    *
    * @return The result as a future to eventually return
    */
-  def submitCode(code: Code): Future[CodeResults]
+  def submitCode(code: Code, kernelOutputStream: Option[OutputStream]): Future[CodeResults]
 
   /** Stops the running broker service. */
   def stop(): Unit

--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerService.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerService.scala
@@ -41,6 +41,7 @@ trait BrokerService {
    * Submits code to the broker service to be executed and return a result.
    *
    * @param code The code to execute
+   * @param kernelOutputStream The output stream to write to
    *
    * @return The result as a future to eventually return
    */

--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerState.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerState.scala
@@ -22,7 +22,8 @@ import java.util.concurrent.ConcurrentHashMap
 import org.apache.toree.interpreter.broker.BrokerTypes._
 import org.slf4j.LoggerFactory
 
-import scala.concurrent.{Promise, Future, promise}
+import scala.concurrent.{Future, Promise}
+import scala.tools.nsc.interpreter.OutputStream
 
 /**
  * Represents the state structure of broker.
@@ -41,6 +42,8 @@ class BrokerState(private val maxQueuedCode: Int) {
     new java.util.concurrent.ConcurrentLinkedQueue[BrokerCode]()
   protected val promiseMap: collection.mutable.Map[CodeId, BrokerPromise] =
     new ConcurrentHashMap[CodeId, BrokerPromise]().asScala
+  protected val outputResultStreamMap : collection.mutable.Map[CodeId, Option[OutputStream]] =
+    new ConcurrentHashMap[CodeId, Option[OutputStream]]().asScala
 
   /**
    * Adds new code to eventually be executed.
@@ -49,7 +52,7 @@ class BrokerState(private val maxQueuedCode: Int) {
    *
    * @return The future containing the results of the execution
    */
-  def pushCode(code: Code): Future[CodeResults] = synchronized {
+  def pushCode(code: Code, outputResultStream: Option[OutputStream]): Future[CodeResults] = synchronized {
     // Throw the standard error if our maximum limit has been reached
     if (codeQueue.size() >= maxQueuedCode)
       throw new IllegalStateException(
@@ -69,8 +72,19 @@ class BrokerState(private val maxQueuedCode: Int) {
     // Add the code to be executed to our queue and the promise to our map
     codeQueue.add(brokerCode)
     promiseMap.put(brokerPromise.codeId, brokerPromise)
-
+    // Maintain an output stream for each codeId
+    outputResultStreamMap.put(brokerPromise.codeId, outputResultStream)
     codeExecutionPromise.future
+  }
+
+  // Called from pyspark
+  def sendOutput(codeId: String, output: String): Unit = {
+    // finds the output stream associated with the code id
+    // and writes to it
+    outputResultStreamMap.get(codeId).get match {
+      case Some(outputStream) => outputStream.write(output.getBytes())
+      case _ => logger.debug(s"Output stream is invalid for codeId $codeId")
+    }
   }
 
   /**

--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerState.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/broker/BrokerState.scala
@@ -52,7 +52,7 @@ class BrokerState(private val maxQueuedCode: Int) {
    *
    * @return The future containing the results of the execution
    */
-  def pushCode(code: Code, outputResultStream: Option[OutputStream]): Future[CodeResults] = synchronized {
+  def pushCode(code: Code, outputResultStream: Option[OutputStream] = None): Future[CodeResults] = synchronized {
     // Throw the standard error if our maximum limit has been reached
     if (codeQueue.size() >= maxQueuedCode)
       throw new IllegalStateException(
@@ -77,10 +77,14 @@ class BrokerState(private val maxQueuedCode: Int) {
     codeExecutionPromise.future
   }
 
-  // Called from pyspark
+  /**
+    * Finds the output stream associated with the given codeId and
+    * writes the output to it.
+    *
+    * @param codeId The id of the code to sendOutput
+    * @param output The output string to be written to the the output stream
+    */
   def sendOutput(codeId: String, output: String): Unit = {
-    // finds the output stream associated with the code id
-    // and writes to it
     outputResultStreamMap.get(codeId).get match {
       case Some(outputStream) => outputStream.write(output.getBytes())
       case _ => logger.debug(s"Output stream is invalid for codeId $codeId")

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerStateSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerStateSpec.scala
@@ -32,11 +32,11 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
         // Fill up to the max of our queue
         for (i <- 1 to TestMaxQueuedCode)
-          brokerState.pushCode(code, None)
+          brokerState.pushCode(code)
 
         // Adding an additional code should throw an exception
         intercept[IllegalStateException] {
-          brokerState.pushCode(code, None)
+          brokerState.pushCode(code)
         }
       }
 
@@ -44,7 +44,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
         val code = "some code"
 
         brokerState.totalQueuedCode() should be (0)
-        brokerState.pushCode(code, None)
+        brokerState.pushCode(code)
         brokerState.totalQueuedCode() should be (1)
       }
     }
@@ -56,7 +56,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
         // Queue up to the maximum test elements, verifying that the total
         // queued element count increases per push
         for (i <- 1 to TestMaxQueuedCode) {
-          brokerState.pushCode(code, None)
+          brokerState.pushCode(code)
           brokerState.totalQueuedCode() should be (i)
         }
       }
@@ -66,7 +66,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       it("should return the next code element if available") {
         val code = "some code"
 
-        brokerState.pushCode(code, None)
+        brokerState.pushCode(code)
 
         brokerState.nextCode().code should be (code)
       }
@@ -101,7 +101,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
     describe("#markSuccess") {
       it("should mark the future for the code as successful") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markSuccess(codeId)
@@ -109,7 +109,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the provided message as the contents of the future") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         val message = "some message"
@@ -118,7 +118,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should do nothing if the code id is invalid") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markSuccess(codeId + "1")
@@ -128,7 +128,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
     describe("#markFailure") {
       it("should mark the future for the code as failure") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markFailure(codeId)
@@ -136,7 +136,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the provided message as the contents of the exception") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         val message = "some message"
@@ -147,7 +147,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should do nothing if the code id is invalid") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markFailure(codeId + "1")
@@ -157,7 +157,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
     describe("#reset") {
       it("should clear any code still in the queue") {
-        brokerState.pushCode("some code", None)
+        brokerState.pushCode("some code")
 
         brokerState.reset("")
 
@@ -165,7 +165,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should mark any evaluating code as a failure if marked true") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
 
         brokerState.reset("")
 
@@ -173,7 +173,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the message as the contents of the failed code futures") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
 
         val message = "some message"
         brokerState.reset(message)
@@ -183,7 +183,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should mark any evaluating code as a success if marked false") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
 
         brokerState.reset("", markAllAsFailure = false)
 
@@ -191,7 +191,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the message as the contents of the successful code futures") {
-        val future = brokerState.pushCode("some code", None)
+        val future = brokerState.pushCode("some code")
 
         val message = "some message"
         brokerState.reset(message, markAllAsFailure = false)

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerStateSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerStateSpec.scala
@@ -16,9 +16,9 @@
  */
 package org.apache.toree.interpreter.broker
 
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
 
-import scala.util.{Failure, Success}
+import scala.util.Success
 
 class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
@@ -32,11 +32,11 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
         // Fill up to the max of our queue
         for (i <- 1 to TestMaxQueuedCode)
-          brokerState.pushCode(code)
+          brokerState.pushCode(code, None)
 
         // Adding an additional code should throw an exception
         intercept[IllegalStateException] {
-          brokerState.pushCode(code)
+          brokerState.pushCode(code, None)
         }
       }
 
@@ -44,7 +44,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
         val code = "some code"
 
         brokerState.totalQueuedCode() should be (0)
-        brokerState.pushCode(code)
+        brokerState.pushCode(code, None)
         brokerState.totalQueuedCode() should be (1)
       }
     }
@@ -56,7 +56,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
         // Queue up to the maximum test elements, verifying that the total
         // queued element count increases per push
         for (i <- 1 to TestMaxQueuedCode) {
-          brokerState.pushCode(code)
+          brokerState.pushCode(code, None)
           brokerState.totalQueuedCode() should be (i)
         }
       }
@@ -66,7 +66,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       it("should return the next code element if available") {
         val code = "some code"
 
-        brokerState.pushCode(code)
+        brokerState.pushCode(code, None)
 
         brokerState.nextCode().code should be (code)
       }
@@ -101,7 +101,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
     describe("#markSuccess") {
       it("should mark the future for the code as successful") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markSuccess(codeId)
@@ -109,7 +109,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the provided message as the contents of the future") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         val message = "some message"
@@ -118,7 +118,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should do nothing if the code id is invalid") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markSuccess(codeId + "1")
@@ -128,7 +128,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
     describe("#markFailure") {
       it("should mark the future for the code as failure") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markFailure(codeId)
@@ -136,7 +136,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the provided message as the contents of the exception") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         val message = "some message"
@@ -147,7 +147,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should do nothing if the code id is invalid") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
         val BrokerCode(codeId, _) = brokerState.nextCode()
 
         brokerState.markFailure(codeId + "1")
@@ -157,7 +157,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
 
     describe("#reset") {
       it("should clear any code still in the queue") {
-        brokerState.pushCode("some code")
+        brokerState.pushCode("some code", None)
 
         brokerState.reset("")
 
@@ -165,7 +165,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should mark any evaluating code as a failure if marked true") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
 
         brokerState.reset("")
 
@@ -173,7 +173,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the message as the contents of the failed code futures") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
 
         val message = "some message"
         brokerState.reset(message)
@@ -183,7 +183,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should mark any evaluating code as a success if marked false") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
 
         brokerState.reset("", markAllAsFailure = false)
 
@@ -191,7 +191,7 @@ class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
       }
 
       it("should use the message as the contents of the successful code futures") {
-        val future = brokerState.pushCode("some code")
+        val future = brokerState.pushCode("some code", None)
 
         val message = "some message"
         brokerState.reset(message, markAllAsFailure = false)

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
@@ -19,14 +19,13 @@ package org.apache.toree.kernel.protocol.v5.interpreter.tasks
 
 import java.io.OutputStream
 
-import akka.actor.{Props, Actor}
+import akka.actor.{Actor, Props}
 import org.apache.toree.global.StreamState
-import org.apache.toree.interpreter.{ExecuteAborted, Results, ExecuteError, Interpreter}
-import org.apache.toree.kernel.api.StreamInfo
+import org.apache.toree.interpreter.{ExecuteAborted, ExecuteError, Interpreter, Results}
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
 import org.apache.toree.security.KernelSecurityManager
-import org.apache.toree.utils.{ConditionalOutputStream, MultiOutputStream, LogLike}
+import org.apache.toree.utils.{ConditionalOutputStream, LogLike, MultiOutputStream}
 
 object ExecuteRequestTaskActor {
   def props(interpreter: Interpreter): Props =
@@ -77,7 +76,7 @@ class ExecuteRequestTaskActor(interpreter: Interpreter) extends Actor with LogLi
 //                Console.setErr(System.err)
 //              }""".trim)
 //            }
-            interpreter.interpret(executeRequest.code.trim)
+            interpreter.interpret(executeRequest.code.trim, outputStreamResult = Some(outputStream))
           }
 
         logger.debug(s"Interpreter execution result was ${success}")

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActorSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActorSpec.scala
@@ -18,16 +18,17 @@
 package org.apache.toree.kernel.protocol.v5.interpreter.tasks
 
 import java.io.OutputStream
+
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
+import com.typesafe.config.ConfigFactory
 import org.apache.toree.interpreter._
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
-import com.typesafe.config.ConfigFactory
+import org.mockito.Matchers.{anyBoolean, anyString, anyObject}
 import org.mockito.Mockito._
-import org.mockito.Matchers.{anyString, anyBoolean}
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{Matchers, FunSpecLike}
+import org.scalatest.{FunSpecLike, Matchers}
 import test.utils.MaxAkkaTestTimeout
 
 object ExecuteRequestTaskActorSpec {
@@ -49,7 +50,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
       it("should return an ExecuteReplyOk if the interpreter returns success") {
         val mockInterpreter = mock[Interpreter]
         doReturn((Results.Success, Left(new ExecuteOutput))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean())
+          .interpret(anyString(), anyBoolean(), anyObject())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -75,7 +76,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
       it("should return an ExecuteReplyAbort if the interpreter returns aborted") {
         val mockInterpreter = mock[Interpreter]
         doReturn((Results.Aborted, Right(mock[ExecuteAborted]))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean())
+          .interpret(anyString(), anyBoolean(), anyObject())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -101,7 +102,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
       it("should return an ExecuteReplyError if the interpreter returns error") {
         val mockInterpreter = mock[Interpreter]
         doReturn((Results.Error, Right(mock[ExecuteError]))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean())
+          .interpret(anyString(), anyBoolean(), anyObject())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -127,7 +128,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
       it("should return ExecuteReplyError if interpreter returns incomplete") {
         val mockInterpreter = mock[Interpreter]
         doReturn((Results.Incomplete, Right(""))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean())
+          .interpret(anyString(), anyBoolean(), anyObject())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -153,7 +154,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
       it("should return an ExecuteReplyOk when receiving empty code.") {
         val mockInterpreter = mock[Interpreter]
         doReturn((Results.Incomplete, Right(""))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean())
+          .interpret(anyString(), anyBoolean(), anyObject())
 
         val executeRequestTask =
           system.actorOf(Props(

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/DataFrameSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/DataFrameSpec.scala
@@ -21,11 +21,11 @@ import org.apache.toree.interpreter._
 import org.apache.toree.kernel.protocol.v5.MIMEType
 import org.apache.toree.magic.dependencies.IncludeKernelInterpreter
 import org.apache.toree.utils.DataFrameConverter
-import org.mockito.Matchers._
-import org.mockito.Matchers.{eq => mockEq}
+import org.mockito.Matchers.{anyString, eq => mockEq, _}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+
 import scala.util.Success
 
 class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter {
@@ -46,7 +46,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val (magic, interpreter, _) = createMocks
         val message: Either[ExecuteOutput, ExecuteFailure] = Right(mock[ExecuteAborted])
         val code = "code"
-        doReturn((Results.Aborted,message)).when(interpreter).interpret(code, false)
+        when(interpreter.interpret(code)).thenReturn((Results.Aborted, message))
         val output = magic.execute(code)
         output.contains(MIMEType.PlainText) should be(true)
         output(MIMEType.PlainText) should be(DataFrameResponses.ErrorMessage(
@@ -62,7 +62,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         doReturn(mockError).when(mockExecuteError).value
         val message: Either[ExecuteOutput, ExecuteFailure] = Right(mockExecuteError)
         val code = "code"
-        doReturn((Results.Error,message)).when(interpreter).interpret(code, false)
+        when(interpreter.interpret(code)).thenReturn((Results.Error, message))
         val output = magic.execute(code)
         output.contains(MIMEType.PlainText) should be(true)
         output(MIMEType.PlainText) should be(DataFrameResponses.ErrorMessage(
@@ -78,7 +78,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         doReturn(mockError).when(mockExecuteError).value
         val message: Either[ExecuteOutput, ExecuteFailure] = Right(mockExecuteError )
         val code = "code"
-        doReturn((Results.Error,message)).when(interpreter).interpret(code, false)
+        when(interpreter.interpret(code)).thenReturn((Results.Error, message))
         val output = magic.execute(code)
         output.contains(MIMEType.PlainText) should be(true)
         output(MIMEType.PlainText) should be(DataFrameResponses.ErrorMessage(
@@ -104,7 +104,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val executeCode =s"""--output=json
                              |${variableName}
                   """.stripMargin
-        doReturn((Results.Success,message)).when(interpreter).interpret(variableName, false)
+        when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
         doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
         doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
         doReturn(Success(outputText)).when(converter).convert(
@@ -124,7 +124,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val executeCode =s"""--output=html
                              |${variableName}
                   """.stripMargin
-        doReturn((Results.Success,message)).when(interpreter).interpret(variableName, false)
+        when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
         doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
         doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
         doReturn(Success(outputText)).when(converter).convert(
@@ -144,7 +144,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val executeCode =s"""--output=csv
                              |${variableName}
                   """.stripMargin
-        doReturn((Results.Success,message)).when(interpreter).interpret(variableName, false)
+        when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
         doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
         doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
         doReturn(Success(outputText)).when(converter).convert(
@@ -164,7 +164,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val executeCode =s"""--output=html --limit=3
                              |${variableName}
                   """.stripMargin
-        doReturn((Results.Success,message)).when(interpreter).interpret(variableName, false)
+        when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
         doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
         doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
         doReturn(Success(outputText)).when(converter).convert(
@@ -180,7 +180,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val message: Either[ExecuteOutput, ExecuteFailure] = Left(outputText)
         val mockDataFrame = mock[org.apache.spark.sql.DataFrame]
         val code = "variable"
-        doReturn((Results.Success,message)).when(interpreter).interpret(code, false)
+        when(interpreter.interpret(code)).thenReturn((Results.Success, message))
         doReturn(Some(code)).when(interpreter).lastExecutionVariableName
         doReturn(Some(mockDataFrame)).when(interpreter).read(code)
         doThrow(new RuntimeException()).when(converter).convert(

--- a/kernel/src/test/scala/test/utils/DummyInterpreter.scala
+++ b/kernel/src/test/scala/test/utils/DummyInterpreter.scala
@@ -19,13 +19,11 @@ package test.utils
 
 import java.net.URL
 
-import org.apache.toree.interpreter.{ExecuteFailure, ExecuteOutput, Interpreter}
 import org.apache.toree.interpreter.Results.Result
+import org.apache.toree.interpreter.{ExecuteFailure, ExecuteOutput, Interpreter}
 import org.apache.toree.kernel.api.KernelLike
-import org.apache.spark.SparkContext
-import org.apache.spark.sql.SQLContext
 
-import scala.tools.nsc.interpreter.{OutputStream, InputStream}
+import scala.tools.nsc.interpreter.{InputStream, OutputStream}
 
 class DummyInterpreter(kernel: KernelLike) extends Interpreter {
   /**
@@ -112,7 +110,7 @@ class DummyInterpreter(kernel: KernelLike) extends Interpreter {
    * @return The success/failure of the interpretation and the output from the
    *         execution or the failure
    */
-  override def interpret(code: String, silent: Boolean): (Result, Either[ExecuteOutput, ExecuteFailure]) = ???
+  override def interpret(code: String, silent: Boolean, outputStreamResult: Option[OutputStream]): (Result, Either[ExecuteOutput, ExecuteFailure]) = ???
 
   /**
    * Attempts to perform code completion via the <TAB> command.

--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -88,7 +88,7 @@ class PySparkInterpreter(
    * @return The success/failure of the interpretation and the output from the
    *         execution or the failure
    */
-  override def interpret(code: String, silent: Boolean, output: Option[OutputStream] = None):
+  override def interpret(code: String, silent: Boolean, output: Option[OutputStream]):
     (Result, Either[ExecuteOutput, ExecuteFailure]) =
   {
     if (!pySparkService.isRunning) pySparkService.start()

--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -18,7 +18,6 @@ package org.apache.toree.kernel.interpreter.pyspark
 
 import java.net.URL
 
-import com.typesafe.config.Config
 import org.apache.toree.interpreter.Results.Result
 import org.apache.toree.interpreter._
 import org.apache.toree.kernel.api.KernelLike
@@ -89,13 +88,13 @@ class PySparkInterpreter(
    * @return The success/failure of the interpretation and the output from the
    *         execution or the failure
    */
-  override def interpret(code: String, silent: Boolean):
+  override def interpret(code: String, silent: Boolean, output: Option[OutputStream] = None):
     (Result, Either[ExecuteOutput, ExecuteFailure]) =
   {
     if (!pySparkService.isRunning) pySparkService.start()
 
     val futureResult = pySparkTransformer.transformToInterpreterResult(
-      pySparkService.submitCode(code)
+      pySparkService.submitCode(code, output)
     )
 
     Await.result(futureResult, Duration.Inf)

--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkService.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkService.scala
@@ -18,11 +18,11 @@ package org.apache.toree.kernel.interpreter.pyspark
 
 import org.apache.toree.interpreter.broker.BrokerService
 import org.apache.toree.kernel.interpreter.pyspark.PySparkTypes._
-import org.apache.spark.SparkContext
 import org.slf4j.LoggerFactory
 import py4j.GatewayServer
 
 import scala.concurrent.Future
+import scala.tools.nsc.interpreter.OutputStream
 
 /**
  * Represents the service that provides the high-level interface between the
@@ -91,8 +91,8 @@ class PySparkService(
    *
    * @return The result as a future to eventually return
    */
-  def submitCode(code: Code): Future[CodeResults] = {
-    pySparkBridge.state.pushCode(code)
+  def submitCode(code: Code, kernelOutputStream: Option[OutputStream]): Future[CodeResults] = {
+    pySparkBridge.state.pushCode(code, kernelOutputStream)
   }
 
   /** Stops the running PySpark service. */

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -260,7 +260,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
     this
   }
 
-  override def interpret(code: String, silent: Boolean = false):
+  override def interpret(code: String, silent: Boolean = false, output: Option[OutputStream]):
   (Results.Result, Either[ExecuteOutput, ExecuteFailure]) = {
     val starting = (Results.Success, Left(""))
     interpretRec(code.trim.split("\n").toList, false, starting)

--- a/sparkr-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sparkr/SparkRInterpreter.scala
+++ b/sparkr-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sparkr/SparkRInterpreter.scala
@@ -78,13 +78,13 @@ class SparkRInterpreter(
    * @return The success/failure of the interpretation and the output from the
    *         execution or the failure
    */
-  override def interpret(code: String, silent: Boolean):
+  override def interpret(code: String, silent: Boolean, output: Option[OutputStream]):
     (Result, Either[ExecuteOutput, ExecuteFailure]) =
   {
     if (!sparkRService.isRunning) sparkRService.start()
 
     val futureResult = sparkRTransformer.transformToInterpreterResult(
-      sparkRService.submitCode(code)
+      sparkRService.submitCode(code, kernelOutputStream = output)
     )
 
     Await.result(futureResult, Duration.Inf)

--- a/sparkr-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sparkr/SparkRService.scala
+++ b/sparkr-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sparkr/SparkRService.scala
@@ -23,6 +23,7 @@ import org.apache.toree.kernel.interpreter.sparkr.SparkRTypes.{Code, CodeResults
 import org.slf4j.LoggerFactory
 
 import scala.concurrent.{Future, future}
+import scala.tools.nsc.interpreter._
 
 /**
  * Represents the service that provides the high-level interface between the
@@ -100,8 +101,8 @@ class SparkRService(
    *
    * @return The result as a future to eventually return
    */
-  override def submitCode(code: Code): Future[CodeResults] = {
-    sparkRBridge.state.pushCode(code)
+  override def submitCode(code: Code, kernelOutputStream: Option[OutputStream]): Future[CodeResults] = {
+    sparkRBridge.state.pushCode(code, kernelOutputStream)
   }
 
   /** Stops the running SparkR service. */

--- a/sql-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sql/SqlInterpreter.scala
+++ b/sql-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sql/SqlInterpreter.scala
@@ -46,13 +46,13 @@ class SqlInterpreter() extends Interpreter {
    * @return The success/failure of the interpretation and the output from the
    *         execution or the failure
    */
-  override def interpret(code: String, silent: Boolean):
+  override def interpret(code: String, silent: Boolean, output: Option[OutputStream]):
     (Result, Either[ExecuteOutput, ExecuteFailure]) =
   {
     if (!sqlService.isRunning) sqlService.start()
 
     val futureResult = sqlTransformer.transformToInterpreterResult(
-      sqlService.submitCode(code)
+      sqlService.submitCode(code, kernelOutputStream = output)
     )
 
     Await.result(futureResult, Duration.Inf)

--- a/sql-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sql/SqlService.scala
+++ b/sql-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sql/SqlService.scala
@@ -16,14 +16,14 @@
  */
 package org.apache.toree.kernel.interpreter.sql
 
-import org.apache.toree.kernel.api.KernelLike
 import java.io.ByteArrayOutputStream
 
 import org.apache.toree.interpreter.broker.BrokerService
+import org.apache.toree.kernel.api.KernelLike
 import org.apache.toree.kernel.interpreter.sql.SqlTypes._
-import org.apache.spark.sql.SQLContext
 
 import scala.concurrent.{Future, future}
+import scala.tools.nsc.interpreter._
 
 /**
  * Represents the service that provides the high-level interface between the
@@ -45,7 +45,7 @@ class SqlService(private val kernel: KernelLike) extends BrokerService {
    *
    * @return The result as a future to eventually return
    */
-  override def submitCode(code: Code): Future[CodeResults] = future {
+  override def submitCode(code: Code, kernelOutputStream: Option[OutputStream]): Future[CodeResults] = future {
     println(s"Executing: '${code.trim}'")
     val result = kernel.sqlContext.sql(code.trim)
 

--- a/test_toree.py
+++ b/test_toree.py
@@ -18,7 +18,7 @@
 import unittest
 import jupyter_kernel_test
 
-class ToreeKernelTests(jupyter_kernel_test.KernelTests):
+class ToreeScalaKernelTests(jupyter_kernel_test.KernelTests):
     # Required --------------------------------------
 
     # The name identifying an installed kernel to run the tests against
@@ -94,6 +94,30 @@ class ToreeKernelTests(jupyter_kernel_test.KernelTests):
             output_msgs.append(msg)
 
         return reply, output_msgs
+
+class ToreePythonKernelTests(jupyter_kernel_test.KernelTests):
+    # Required --------------------------------------
+
+    # The name identifying an installed kernel to run the tests against
+    kernel_name = "apache_toree_pyspark"
+
+    # language_info.name in a kernel_info_reply should match this
+    language_name = "scala"
+
+    # Optional --------------------------------------
+
+    # the normal file extension (including the leading dot) for this language
+    # checked against language_info.file_extension in kernel_info_reply
+    file_extension = ".py"
+
+    # Code in the kernel's language to write "hello, world" to stdout
+    code_hello_world = "print(\"hello, world\")"
+
+    # Samples of code which generate a result value (ie, some text
+    # displayed as Out[n])
+    code_execute_result = [
+        {'code': '6*7', 'result': '42'}
+    ]
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
[TOREE-318](https://issues.apache.org/jira/browse/TOREE-318)
* Passes the output stream into the BrokerState and maps it to the code_id, so that the interpreter can call sendOutput with the code_id and write to the correct output stream.
* Makes use of python's AST parser to figure out if the last code statement in the request is an expression, if its an expression it will send output to the stream immediately from stdout, else assign the last statement to a temp variable where it is evaluated and if that has output return it as an execute result.
* Added system test coverage using the Jupyter kernel tester, which will test a print statement and a execute result producing arithmetic expression.  Note the kernel tester will test pyspark now as well as scala spark.