### PR TITLE
Wrapping the kernel object in a python class

### DIFF
--- a/pyspark-interpreter/src/main/resources/PySpark/pyspark_runner.py
+++ b/pyspark-interpreter/src/main/resources/PySpark/pyspark_runner.py
@@ -94,6 +94,13 @@ class Kernel(object):
     def __init__(self, jkernel):
         self._jvm_kernel = jkernel
 
+    def __getattr__(self, name):
+        return self._jvm_kernel.__getattribute__(name)
+
+    def __dir__(self):
+        parent = super().__dir__()
+        return parent + [x for x in self._jvm_kernel.__dir__() if x not in parent]
+
     def createSparkContext(self, config):
         jconf = gateway.jvm.org.apache.spark.SparkConf(False)
         for key,value in config.getAll():

--- a/test_toree.py
+++ b/test_toree.py
@@ -29,10 +29,6 @@ class ToreeScalaKernelTests(jupyter_kernel_test.KernelTests):
 
     # Optional --------------------------------------
 
-    # the normal file extension (including the leading dot) for this language
-    # checked against language_info.file_extension in kernel_info_reply
-    file_extension = ".scala"
-
     # Code in the kernel's language to write "hello, world" to stdout
     code_hello_world = "println(\"hello, world\")"
 
@@ -105,10 +101,6 @@ class ToreePythonKernelTests(jupyter_kernel_test.KernelTests):
     language_name = "scala"
 
     # Optional --------------------------------------
-
-    # the normal file extension (including the leading dot) for this language
-    # checked against language_info.file_extension in kernel_info_reply
-    file_extension = ".py"
 
     # Code in the kernel's language to write "hello, world" to stdout
     code_hello_world = "print(\"hello, world\")"


### PR DESCRIPTION
The current python runner is a touch broken, not in the least due to an oddity that can lead to multiple gateways if you create a Python SparkConf object.

This PR aims to address that issue, and as a useful consequence permit more pythonic use of the kernel object:
```
conf = (
  SparkConf()
            .setMaster("local[1]")
            .setAppName("Jupyter PySpark")
)
kernel.createSparkContext(conf)
```