### PR TITLE
[TOREE-334] java.util.NoSuchElementException on empty magic

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/magic/MagicParser.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/magic/MagicParser.scala
@@ -22,7 +22,7 @@ import org.apache.toree.magic.MagicManager
 import scala.util.Try
 
 class MagicParser(private val magicManager: MagicManager) {
-  private val magicRegex = """^[%]{1,2}(\w+)""".r
+  private val magicRegex = """^[%]{1,2}(\w*)""".r
   protected[magic] val kernelObjectName = "kernel.magics"
 
   /**


### PR DESCRIPTION
Change magicRegex to handle `%` magic line

Before patch (kernel killed)
```
%
java.util.NoSuchElementException: None.get
        at scala.None$.get(Option.scala:347)
        at scala.None$.get(Option.scala:345)
        at org.apache.toree.kernel.protocol.v5.magic.MagicParser$$anonfun$parseOutInvalidMagics$2.apply(MagicParser.scala:93)
        at org.apache.toree.kernel.protocol.v5.magic.MagicParser$$anonfun$parseOutInvalidMagics$2.apply(MagicParser.scala:92)
        at scala.collection.immutable.List.map(List.scala:273)
        at org.apache.toree.kernel.protocol.v5.magic.MagicParser.parseOutInvalidMagics(MagicParser.scala:92)
        at org.apache.toree.kernel.protocol.v5.magic.MagicParser.parseLines(MagicParser.scala:153)
        at org.apache.toree.kernel.protocol.v5.magic.MagicParser.parse(MagicParser.scala:174)
        at org.apache.toree.kernel.protocol.v5.relay.ExecuteRequestRelay$$anonfun$receive$1.applyOrElse(ExecuteRequestRelay.scala:109)
        at akka.actor.Actor$class.aroundReceive(Actor.scala:484)
        at org.apache.toree.kernel.protocol.v5.relay.ExecuteRequestRelay.aroundReceive(ExecuteRequestRelay.scala:36)
        at akka.actor.ActorCell.receiveMessage(ActorCell.scala:526)
        at akka.actor.ActorCell.invoke(ActorCell.scala:495)
        at akka.dispatch.Mailbox.processMailbox(Mailbox.scala:257)
        at akka.dispatch.Mailbox.run(Mailbox.scala:224)
        at akka.dispatch.Mailbox.exec(Mailbox.scala:234)
        at scala.concurrent.forkjoin.ForkJoinTask.doExec(ForkJoinTask.java:260)
        at scala.concurrent.forkjoin.ForkJoinPool$WorkQueue.runTask(ForkJoinPool.java:1339)
        at scala.concurrent.forkjoin.ForkJoinPool.runWorker(ForkJoinPool.java:1979)
        at scala.concurrent.forkjoin.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:107
```
After patch:
```
%
Name: Error parsing magics!
Message: Magics [] do not exist!
StackTrace: 
```