### PR TITLE
TOREE-341 Fixed exception stack traces getting lost.

### DIFF
--- a/kernel/src/test/scala/integration/PostProcessorSpecForIntegration.scala
+++ b/kernel/src/test/scala/integration/PostProcessorSpecForIntegration.scala
@@ -19,10 +19,10 @@ package integration
 
 import java.io.OutputStream
 
-import org.apache.toree.kernel.api.KernelLike
+import org.apache.toree.kernel.api.Kernel
 import org.apache.toree.kernel.interpreter.scala.ScalaInterpreter
 import org.apache.toree.kernel.protocol.v5.magic.PostProcessor
-import org.apache.toree.utils.{MultiOutputStream, TaskManager}
+import org.apache.toree.utils.{MultiOutputStream}
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 
@@ -37,12 +37,9 @@ class PostProcessorSpecForIntegration extends FunSpec with Matchers
     //       for performance improvements
     scalaInterpreter = new ScalaInterpreter {
       override protected val multiOutputStream = MultiOutputStream(List(mock[OutputStream], lastResultOut))
-
-      override protected def bindKernelVariable(kernel: KernelLike): Unit = { }
     }
 
-    // scalaInterpreter.start()
-    scalaInterpreter.init(mock[KernelLike])
+    scalaInterpreter.init(mock[Kernel])
 
     postProcessor = new PostProcessor(scalaInterpreter)
   }

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -352,7 +352,9 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
   }
 
   private def retrieveLastException: Throwable = {
-    iMain.interpret("_exceptionHack.lastException = lastException")
+    iMain.beSilentDuring {
+      iMain.interpret("_exceptionHack.lastException = lastException")
+    }
     exceptionHack.lastException
   }
 
@@ -423,7 +425,8 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
           "Compile Error", output, List()
         )
       else
-        ExecuteError("Unknown", "Unable to retrieve error!", List())
+        // May as capture the output here.  Could be useful
+        ExecuteError("Unknown Error", output, List())
   }
 }
 

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -296,7 +296,7 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
       iMain.interpret("import org.apache.spark.SparkContext._")
 
       logger.debug("Adding the hack for the exception handling retrieval.")
-      iMain.bind("_exceptionHack", exceptionHack)
+      iMain.bind("_exceptionHack", classOf[ExceptionHack].getName, exceptionHack, List("@transient"))
     }
 
     this


### PR DESCRIPTION
This is a rather ugly fix to address the issue caused by
https://issues.scala-lang.org/browse/SI-8935

The crux of the issue is that valueOfTerm returns None -- always

This introduces a small class that is bound into the REPL scope so that we
can modify its internal state and use that to retrieve values.

We can extend this to a more general case later on if needed.