### PR TITLE
The default spark application name for Toree is still IBM Spark Kernel.

### DIFF
--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
@@ -43,7 +43,7 @@ object SparkKernelInfo {
   /**
    * Represents the displayed name of the kernel.
    */
-  val banner                  = "IBM Spark Kernel"
+  val banner                  = "Apache Toree"
 
   /**
    * Represents the name of the user who started the kernel process.


### PR DESCRIPTION
Lets fix that.