### PR TITLE
Fix for cell and line magics

### DIFF
--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -258,12 +258,11 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
    */
   override def read(variableName: String): Option[AnyRef] = {
     require(iMain != null)
-    val variable = iMain.valueOfTerm(variableName)
-    if (variable == null || variable.isEmpty) None
-    else variable match {
-      case Some(v: AnyRef)  => Some(v)
-      case Some(_)          => None // Don't support AnyVal yet
-      case None             => None
+
+    iMain.eval(variableName) match {
+      case null => None
+      case str: String if str.isEmpty => None
+      case res => Some(res)
     }
   }
 

--- a/scala-interpreter/src/test/scala-2.11/scala/ScalaInterpreterSpec.scala
+++ b/scala-interpreter/src/test/scala-2.11/scala/ScalaInterpreterSpec.scala
@@ -341,11 +341,11 @@ class ScalaInterpreterSpec extends FunSpec
         }
       }
 
-      it("should execute the underlying valueOfTerm method") {
+      it("should execute the underlying eval method") {
         interpreter.start()
         interpreter.read("someVariable")
 
-        verify(mockSparkIMain).valueOfTerm(anyString())
+        verify(mockSparkIMain).eval(anyString())
       }
     }
 


### PR DESCRIPTION
Magics are not working properly on the scala 2.11 / spark 2.0 master branch. For example using the html magic:

`%%html`
`<b>foo</b>`

will return 

`Left(Map(text/html -> <b>foo</b>))`

The problem is in the scala IMain repl used in the 2.11 version of ScalaInterpreterSpecific read method. IMain valueOfTerm is not working properly when given a variable name. IMain eval is working however.