### PR TITLE
Changes in responds to feedback on 0.1.0 rc1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -198,8 +198,8 @@ publish-jars:
 ################################################################################
 # PIP PACKAGE
 ################################################################################
-dist/toree-pip/toree-$(BASE_VERSION).tar.gz: DOCKER_WORKDIR=/srv/toree/dist/toree-pip
-dist/toree-pip/toree-$(BASE_VERSION).tar.gz: dist/toree
+dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz: DOCKER_WORKDIR=/srv/toree/dist/toree-pip
+dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz: dist/toree
 	@mkdir -p dist/toree-pip
 	@cp -r dist/toree dist/toree-pip
 	@cp dist/toree/LICENSE dist/toree-pip/LICENSE
@@ -211,15 +211,15 @@ dist/toree-pip/toree-$(BASE_VERSION).tar.gz: dist/toree
 	@cp -rf etc/pip_install/* dist/toree-pip/.
 	@$(GEN_PIP_PACKAGE_INFO)
 	@$(DOCKER) --user=root $(IMAGE) python setup.py sdist --dist-dir=.
-	@$(DOCKER) -p 8888:8888 --user=root  $(IMAGE) bash -c	'pip install toree-$(BASE_VERSION).tar.gz && jupyter toree install'
-#	-@(cd dist/toree-pip; find . -not -name 'toree-$(VERSION).tar.gz' -maxdepth 1 | xargs rm -r )
+	@$(DOCKER) -p 8888:8888 --user=root  $(IMAGE) bash -c	'pip install apache-toree-$(BASE_VERSION).tar.gz && jupyter toree install'
+	-@(cd dist/toree-pip; find . -not -name 'apache-toree-$(BASE_VERSION).tar.gz' -maxdepth 1 | xargs rm -r )
 
-pip-release: dist/toree-pip/toree-$(BASE_VERSION).tar.gz
+pip-release: dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz
 
-dist/toree-pip/toree-$(BASE_VERSION).tar.gz.md5 dist/toree-pip/toree-$(BASE_VERSION).tar.gz.asc dist/toree-pip/toree-$(BASE_VERSION).tar.gz.sha: dist/toree-pip/toree-$(BASE_VERSION).tar.gz
-	@GPG_PASSWORD='$(GPG_PASSWORD)' GPG=$(GPG) etc/tools/./sign-file dist/toree-pip/toree-$(BASE_VERSION).tar.gz
+dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz.md5 dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz.asc dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz.sha: dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz
+	@GPG_PASSWORD='$(GPG_PASSWORD)' GPG=$(GPG) etc/tools/./sign-file dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz
 
-sign-pip: dist/toree-pip/toree-$(BASE_VERSION).tar.gz.md5 dist/toree-pip/toree-$(BASE_VERSION).tar.gz.asc dist/toree-pip/toree-$(BASE_VERSION).tar.gz.sha
+sign-pip: dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz.md5 dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz.asc dist/toree-pip/apache-toree-$(BASE_VERSION).tar.gz.sha
 
 publish-pip: DOCKER_WORKDIR=/srv/toree/dist/toree-pip
 publish-pip: PYPI_REPO?=https://pypi.python.org/pypi
@@ -229,37 +229,37 @@ publish-pip: PYPIRC=printf "[distutils]\nindex-servers =\n\tpypi\n\n[pypi]\nrepo
 publish-pip: sign-pip
 	@$(DOCKER) $(IMAGE) bash -c '$(PYPIRC) pip install twine && \
 		python setup.py register -r $(PYPI_REPO) && \
-		twine upload -r pypi toree-$(BASE_VERSION).tar.gz toree-$(BASE_VERSION).tar.gz.asc'
+		twine upload -r pypi apache-toree-$(BASE_VERSION).tar.gz apache-toree-$(BASE_VERSION).tar.gz.asc'
 
 ################################################################################
 # BIN PACKAGE
 ################################################################################
-dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz: dist/toree
+dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz: dist/toree
 	@mkdir -p dist/toree-bin
-	@(cd dist; tar -cvzf toree-bin/toree-$(VERSION)-binary-release.tar.gz toree)
+	@(cd dist; tar -cvzf toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz toree)
 
-bin-release: dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz
+bin-release: dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz
 
-dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz.md5 dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz.asc dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz.sha: dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz
-	@GPG_PASSWORD='$(GPG_PASSWORD)' GPG=$(GPG) etc/tools/./sign-file dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz
+dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz.md5 dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz.asc dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz.sha: dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz
+	@GPG_PASSWORD='$(GPG_PASSWORD)' GPG=$(GPG) etc/tools/./sign-file dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz
 
-sign-bin: dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz.md5 dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz.asc dist/toree-bin/toree-$(VERSION)-binary-release.tar.gz.sha
+sign-bin: dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz.md5 dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz.asc dist/toree-bin/apache-toree-$(VERSION)-binary-release.tar.gz.sha
 
 publish-bin:
 
 ################################################################################
 # SRC PACKAGE
 ################################################################################
-dist/toree-src/toree-$(VERSION)-source-release.tar.gz:
+dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz:
 	@mkdir -p dist/toree-src
-	@tar -X 'etc/.src-release-ignore' -cvzf dist/toree-src/toree-$(VERSION)-source-release.tar.gz .
+	@tar -X 'etc/.src-release-ignore' -cvzf dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz .
 
-src-release: dist/toree-src/toree-$(VERSION)-source-release.tar.gz
+src-release: dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz
 
-dist/toree-src/toree-$(VERSION)-source-release.tar.gz.md5 dist/toree-src/toree-$(VERSION)-source-release.tar.gz.asc dist/toree-src/toree-$(VERSION)-source-release.tar.gz.sha: dist/toree-src/toree-$(VERSION)-source-release.tar.gz
-	@GPG_PASSWORD='$(GPG_PASSWORD)' GPG=$(GPG) etc/tools/./sign-file dist/toree-src/toree-$(VERSION)-source-release.tar.gz
+dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz.md5 dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz.asc dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz.sha: dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz
+	@GPG_PASSWORD='$(GPG_PASSWORD)' GPG=$(GPG) etc/tools/./sign-file dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz
 
-sign-src: dist/toree-src/toree-$(VERSION)-source-release.tar.gz.md5 dist/toree-src/toree-$(VERSION)-source-release.tar.gz.asc dist/toree-src/toree-$(VERSION)-source-release.tar.gz.sha
+sign-src: dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz.md5 dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz.asc dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz.sha
 
 publish-src:
 

--- a/Makefile
+++ b/Makefile
@@ -250,9 +250,11 @@ publish-bin:
 ################################################################################
 # SRC PACKAGE
 ################################################################################
-dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz:
+dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz: dist/toree-legal
 	@mkdir -p dist/toree-src
-	@tar -X 'etc/.src-release-ignore' -cvzf dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz .
+	@tar -X 'etc/.src-release-ignore' -cvf dist/toree-src/apache-toree-$(VERSION)-source-release.tar .
+	@tar -rvf dist/toree-src/apache-toree-$(VERSION)-source-release.tar -C dist/toree-legal .
+	@gzip dist/toree-src/apache-toree-$(VERSION)-source-release.tar
 
 src-release: dist/toree-src/apache-toree-$(VERSION)-source-release.tar.gz
 

--- a/etc/.src-release-ignore
+++ b/etc/.src-release-ignore
@@ -14,3 +14,4 @@ licenses
 derby.log
 etc/tools/apache-rat-0.11.jar
 kernel/lib/mesos-0.18.1-shaded-protobuf.jar
+*-ivy.xml

--- a/etc/.src-release-ignore
+++ b/etc/.src-release-ignore
@@ -1,5 +1,6 @@
 target
 dist
+etc/legal
 .git
 .idea
 .vagrant
@@ -8,9 +9,6 @@ examples
 metastore_db
 .ensime/*
 .ensime_cache/*
-LICENSE_extras
-NOTICE_extras
-licenses
 derby.log
 etc/tools/apache-rat-0.11.jar
 kernel/lib/mesos-0.18.1-shaded-protobuf.jar

--- a/etc/.src-release-ignore
+++ b/etc/.src-release-ignore
@@ -11,4 +11,6 @@ metastore_db
 LICENSE_extras
 NOTICE_extras
 licenses
-
+derby.log
+etc/tools/apache-rat-0.11.jar
+kernel/lib/mesos-0.18.1-shaded-protobuf.jar

--- a/etc/legal/NOTICE_extras
+++ b/etc/legal/NOTICE_extras
@@ -1,1 +1,26 @@
 ========================================================================
+
+Copyright (c) 2000-2011 INRIA, France Telecom
+
+========================================================================
+
+Copyright (c) 2004-2011 Brian M. Clapper.
+
+========================================================================
+
+Copyright (c) 2002-2016 EPFL
+Copyright (c) 2011-2016 Lightbend, Inc. (formerly Typesafe, Inc.)
+
+========================================================================
+
+Copyright (c) 2009-2012 Stanford University, unless otherwise specified.
+
+========================================================================
+
+Copyright (c) 2009-2014 Tony Morris, Runar Bjarnason, Tom Adams, Kristian Domagala, Brad Clow, Ricky Clarkson, Paul Chiusano, Trygve Laugstøl, Nick Partridge, Jason Zaugg
+
+========================================================================
+
+Copyright (c) 2004-2013 QOS.ch
+
+

--- a/etc/pip_install/setup.py
+++ b/etc/pip_install/setup.py
@@ -26,7 +26,7 @@ with open(os.path.join(here, 'toree', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
 setup_args = dict(
-    name='toree',
+    name='apache-toree',
     author='Apache Toree Development Team',
     author_email='dev@toree.incubator.apache.org',
     description='A Jupyter kernel for enabling remote applications to interaction with Apache Spark.',


### PR DESCRIPTION
From @lresende 
- [x] Artifacts and extracted folders are probably best if called apache-toree-xxxx
- [x]  BSD licenses require notice (http://software.clapper.org/grizzled-scala/license.html) and should go under notice or copied into the LICENSE file
- [x] Source package has derby.log
- [x] Source package has binary jars : ./etc/tools/apache-rat-0.11.jar ./kernel/lib/mesos-0.18.1-shaded-protobuf.jar
- [x] And I believe these other jars are for test purposes, which then might be ok
```
./scala-interpreter/src/test/resources/ScalaTestJar.jar
./scala-interpreter/src/test/resources/TestJar.jar
./scala-interpreter/src/test/resources/TestJar2.jar
./sparkr-interpreter/src/main/resources/R/pkg/inst/test_support/sparktestjar_2.10-1.0.jar
```
~~- [ ] rat is giving the following unapproved licenses~~
   * there is an exclude file that will ignore many of the files below

```
Unapproved licenses:

  ./.example-image
  ./.jvmopts
  ./README.md
  ./RELEASE_NOTES.md
  ./derby.log
  ./index.ipynb
  ./client/src/main/resources/client-ivy.xml
  ./client/src/main/resources/toree-client-ivy.xml
  ./client/src/test/resources/kernel-profiles/IOPubIntegrationProfile.json
  ./communication/src/main/resources/toree-communication-ivy.xml
  ./etc/.src-release-ignore
  ./etc/kernel.json
  ./etc/pip_install/MANIFEST.in
  ./kernel/src/main/resources/toree-kernel-ivy.xml
  ./kernel/src/test/resources/fixtures/profile.json
  ./kernel-api/src/main/resources/toree-kernel-api-ivy.xml
  ./macros/src/main/resources/toree-macros-ivy.xml
  ./plugins/src/main/resources/toree-plugins-ivy.xml
  ./protocol/src/main/resources/toree-protocol-ivy.xml
  ./pyspark-interpreter/src/main/resources/toree-pyspark-interpreter-ivy.xml
  ./scala-interpreter/src/main/resources/toree-scala-interpreter-ivy.xml
  ./sparkr-interpreter/src/main/resources/README.md
  ./sparkr-interpreter/src/main/resources/package-sparkR.sh
  ./sparkr-interpreter/src/main/resources/toree-sparkr-interpreter-ivy.xml
  ./sparkr-interpreter/src/main/resources/R/.gitignore
  ./sparkr-interpreter/src/main/resources/R/DOCUMENTATION.md
  ./sparkr-interpreter/src/main/resources/R/README.md
  ./sparkr-interpreter/src/main/resources/R/WINDOWS.md
  ./sparkr-interpreter/src/main/resources/R/pkg/.lintr
  ./sparkr-interpreter/src/main/resources/R/pkg/DESCRIPTION
  ./sparkr-interpreter/src/main/resources/R/pkg/NAMESPACE
  ./sql-interpreter/src/main/resources/toree-sql-interpreter-ivy.xml
  ./src/main/resources/root-ivy.xml
  ./src/main/resources/toree-ivy.xml
```

- [x]  Please do a grep -ri SNAPSHOT * which is showing a bunch of SPANSHOT
dependencies... this seems wrong