### PR TITLE
Fix missing "test" modifier

### DIFF
--- a/project/common.scala
+++ b/project/common.scala
@@ -146,7 +146,9 @@ object Common {
     // Test dependencies
     libraryDependencies ++= Seq(
       "org.scalatest" %% "scalatest" % "2.2.6" % "test", // Apache v2
-      "org.mockito" % "mockito-all" % "1.10.19" % "test"   // MIT
+      "org.mockito" % "mockito-all" % "1.10.19" % "test",   // MIT
+      // use the same jackson version in test than the one provided at runtime by Spark 2.0.0
+      "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5" % "test" // Apache v2
     ),
     ScoverageSbtPlugin.ScoverageKeys.coverageHighlighting := false,
     pomExtra :=

--- a/protocol/build.sbt
+++ b/protocol/build.sbt
@@ -29,6 +29,5 @@ libraryDependencies ++= Seq(
 // TEST DEPENDENCIES
 //
 libraryDependencies ++= Seq(
-  "org.scalactic" %% "scalactic" % "2.2.6" % "test", // Apache v2
-  "com.fasterxml.jackson.core" % "jackson-databind" % "2.7.4" // Apache v2
+  "org.scalactic" %% "scalactic" % "2.2.6" % "test" // Apache v2
 )


### PR DESCRIPTION
Missing "test" modifier causes jackson 2.7.4 libs to be unnecessarily included in the toree assembly.

If the toree assembly gets on the main Spark classpath (via spark.driver.extraClassPath)  this causes
       com.fasterxml.jackson.databind.JsonMappingException: Incompatible Jackson version: 2.7.4
...     at org.apache.spark.util.JsonProtocol$.<clinit>
because Spark 2.0 is built against a lower jackson version (2.6.5)