### PR TITLE
Fixed staging url and organization name, disabled coursier due to issues

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/Main.scala
+++ b/kernel/src/main/scala/org/apache/toree/Main.scala
@@ -19,7 +19,6 @@ package org.apache.toree
 
 import org.apache.toree.boot.layer._
 import org.apache.toree.boot.{CommandLineOptions, KernelBootstrap}
-import org.apache.toree.kernel.BuildInfo
 
 object Main extends App {
   private val options = new CommandLineOptions(args)

--- a/project/common.scala
+++ b/project/common.scala
@@ -20,7 +20,7 @@ import sbt.Keys._
 import sbtbuildinfo._
 import sbtbuildinfo.BuildInfoKeys._
 import scoverage.ScoverageSbtPlugin
-import coursier.Keys._
+//import coursier.Keys._
 import com.typesafe.sbt.pgp.PgpKeys._
 import scala.util.{Try, Properties}
 
@@ -30,7 +30,7 @@ object Common {
   private val snapshot                  = Properties.envOrElse("IS_SNAPSHOT","true").toBoolean
   private val gpgLocation               = Properties.envOrElse("GPG","/usr/local/bin/gpg")
   private val gpgPassword               = Properties.envOrElse("GPG_PASSWORD","")
-  private val buildOrganization         = "org.apache.toree.kernel"
+  private val buildOrganization         = "org.apache.toree"
   private val buildVersion              = if (snapshot) s"$versionNumber-SNAPSHOT" else versionNumber
   private val buildScalaVersion         = "2.10.4"
 
@@ -167,7 +167,7 @@ object Common {
     mappings in packageBin in Compile += file("LICENSE") -> "LICENSE",
     mappings in packageBin in Compile += file("NOTICE") -> "NOTICE",
 
-    coursierVerbosity := {
+    /*coursierVerbosity := {
       val level = Try(Integer.valueOf(Properties.envOrElse(
         "TOREE_RESOLUTION_VERBOSITY", "1")
       ).toInt).getOrElse(1)
@@ -177,7 +177,7 @@ object Common {
       )
 
       level
-    },
+    },*/
 
     scalacOptions in (Compile, doc) ++= Seq(
       // Ignore packages (for Scaladoc) not from our project
@@ -232,9 +232,9 @@ object Common {
       if (isSnapshot.value)
         Some("Apache Staging Repo" at "https://repository.apache.org/content/repositories/snapshots/")
       else
-        Some("Apache Staging Repo" at "https://repository.apache.org/content/repositories/staging/")
+        Some("Apache Staging Repo" at "https://repository.apache.org/service/local/staging/deploy/maven2/")
     },
-    credentials += Credentials(Path.userHome / ".ivy2" / ".credentials"),
+    publishMavenStyle := true,
 
     // Add rebuild ivy xml to the following tasks
     compile <<= (compile in Compile) dependsOn (rebuildIvyXml dependsOn deliverLocal)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -50,7 +50,7 @@ addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
 addSbtPlugin("com.typesafe.sbt" % "sbt-ghpages" % "0.5.3")
 
 // Provides alternative resolving/downloading over sbt
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
+//addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.0-M12")
 
 //  Used for signing jars published via `sbt publish-signed`
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")

--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/SparkKernelInfo.scala
@@ -17,7 +17,7 @@
 
 package org.apache.toree.kernel.protocol.v5
 
-import org.apache.toree.kernel.BuildInfo
+import org.apache.toree.BuildInfo
 
 object SparkKernelInfo {
   /**


### PR DESCRIPTION
@lbustelo, @Lull3rSkat3r, @mariusvniekerk This fixes the url needed to publish to the staging repository. We also had the wrong organization name when publishing, so I've resolved that as well.

As for coursier, I was getting binary compatibility issues to do with missing methods. For now, it's disabled (for building our project, not using in our magics).

Will need to update the url and organization name in 0.2.x as well.