### PR TITLE
Issue 361 - use latest all-spark-notebook image on master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 APACHE_SPARK_VERSION?=2.0.0
 SCALA_VERSION?=2.11
-IMAGE?=jupyter/all-spark-notebook
+IMAGE?=jupyter/all-spark-notebook:228ae7a44e0c
 EXAMPLE_IMAGE?=apache/toree-examples
 SYSTEM_TEST_IMAGE?=apache/toree-systemtest
 GPG?=gpg

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ endif
 
 APACHE_SPARK_VERSION?=2.0.0
 SCALA_VERSION?=2.11
-IMAGE?=jupyter/all-spark-notebook:07a7c4d6d447
+IMAGE?=jupyter/all-spark-notebook
 EXAMPLE_IMAGE?=apache/toree-examples
 SYSTEM_TEST_IMAGE?=apache/toree-systemtest
 GPG?=gpg


### PR DESCRIPTION
This change removes the image tag from the jupyter/all-spark-notebook image used to build the examples image (during `make dev`).  That tagged image contained an older and incompatible version of spark (1.6) that rendered some of the updated examples from succeeding as they relied on spark 2.0 functionality.

Moving forward it seems like we should let the master branch use the latest version of the all-spark-notebook (and thus not reference a tag value).  There are two conditions that would warrant exceptions to this...
1. When capturing releases, we should probably tag the examples reference to the current image.
2. Should any all-spark-notebook image be rendered invalid we might want to pin the examples image to the last known working image (at least until the image can be fixed).

This change was tested by performing a dev build `make dev` and confirming the `%%Dataframe` magic could be successfully invoked from magic-tutorial.ipynb.