### PR TITLE
[TOREE-365] Show REPL declarations in notebooks

### DIFF
--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -162,28 +162,23 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
       interpretRec(code.trim.split("\n").toList, false, starting)
    }
 
-   def truncateResult(result:String, showType:Boolean =false, noTruncate: Boolean = false): String = {
-     val resultRX="""(?s)(res\d+):\s+(.+)\s+=\s+(.*)""".r
+   def truncateResult(result: String, showType: Boolean = false, noTruncate: Boolean = false): String = {
+     val resultRX = """(?s)(res\d+):\s+(.+)\s+=\s+(.*)""".r
 
      result match {
-       case resultRX(varName,varType,resString) => {
-           var returnStr=resString
-           if (noTruncate)
-           {
-             val r=read(varName)
-             returnStr=r.getOrElse("").toString
-           }
-
-           if (showType)
-             returnStr=varType+" = "+returnStr
-
+       case resultRX(varName,varType,resString) =>
+         var returnStr = resString
+         if (noTruncate) {
+           val r = read(varName)
+           returnStr = r.getOrElse("").toString
+         }
+         if (showType) {
+           returnStr = s"$varType = $returnStr"
+         }
          returnStr
 
-       }
-       case _ => ""
+       case str => str
      }
-
-
    }
 
    protected def interpretRec(lines: List[String], silent: Boolean = false, results: (Results.Result, Either[ExecuteOutput, ExecuteFailure])): (Results.Result, Either[ExecuteOutput, ExecuteFailure]) = {


### PR DESCRIPTION
Always print the result of an evaluation, regardless if is an expression that is printed as `resX: <expr>`, or a declaration that does not contain the "resX:" part, such as "defined class Foo".