### PR TITLE
Add git configuration for line ending

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,13 @@
+# Set the default behavior to have all files normalized to Unix-style
+# line endings upon check-in.
+* text=auto
+
+# Declare files that will always have CRLF line endings on checkout.
+*.bat text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.dll binary
+*.exp binary
+*.lib binary
+*.pdb binary
+*.exe binary


### PR DESCRIPTION
Git relies on user setting core.autocrlf which
is ususally unreliable as not all users are aware
of this configuration, or they forget to properly set.

The .gitattributes file is a template file with the
appropriate configuration for different file types.

After these changes are applied it's recommended to
do the following commands on your local repository:

git rm --cached -r .
git reset --hard

More info available at
https://help.github.com/articles/dealing-with-line-endings/