### PR TITLE
Fix system tests

### DIFF
--- a/Dockerfile.system-test
+++ b/Dockerfile.system-test
@@ -28,7 +28,7 @@ ENV APACHE_SPARK_VERSION 2.0.0
 # Temporarily add jessie backports to get openjdk 8, but then remove that source
 RUN echo 'deb http://ftp.debian.org/debian jessie-backports main' > /etc/apt/sources.list.d/jessie-backports.list && \
     apt-get -y update && \
-    apt-get install -y --no-install-recommends openjdk-8-jre-headless && \
+    apt-get install -y --no-install-recommends -t jessie-backports openjdk-8-jre-headless && \
     rm /etc/apt/sources.list.d/jessie-backports.list && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
CI is currently failing due to system tests.

Check http://unix.stackexchange.com/questions/342403/openjdk-8-jre-headless-depends-ca-certificates-java-but-it-is-not-going-to-be for an explanation of the fix.