### PR TITLE
TOREE-377: When magic fails, log the error.

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/magic/MagicManager.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/magic/MagicManager.scala
@@ -108,7 +108,7 @@ class MagicManager(private val pluginManager: PluginManager) extends Dynamic {
       }
       case Failure(t) =>
         val message =  s"Magic $name failed to execute with error: \n${t.getMessage}"
-        logger.warn(message)
+        logger.warn(message, t)
         Left(CellMagicOutput("text/plain" -> message))
   }
 }


### PR DESCRIPTION
This adds the error thrown in magic to the log, but not to the jupyter client.