### PR TITLE
TOREE-378: Fix is_complete_handler responses.

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/IsCompleteHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/IsCompleteHandler.scala
@@ -48,7 +48,7 @@ class IsCompleteHandler(actorLoader: ActorLoader)
     val codeCompleteFuture = ask(interpreterActor, cr).mapTo[(String, String)]
     codeCompleteFuture.onComplete {
       case Success(tuple) =>
-        val reply = IsCompleteReply(tuple._1, tuple._1)
+        val reply = IsCompleteReply(tuple._1, tuple._2)
         val isCompleteReplyType = MessageType.Outgoing.IsCompleteReply.toString
         logKernelMessageAction("Sending is complete reply for", km)
         actorLoader.load(SystemActorType.KernelMessageRelay) !


### PR DESCRIPTION
This commit includes a bug fix to send indentation instead of the
response twice.

This also updates the is-complete check to require a blank line to end a
multi-line block, which is the way ipython behaves. This avoids running
code when a user intends to continue a block.

Last, this updates the indentation heuristic. First, indentation is
taken from the previous line's starting indentation (before, the first
white space was used). Then, if the interpreter detects `=>` or `{`, it
adds two additional spaces.