### PR TITLE
TOREE-379: Fix code completion reply.

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CodeCompleteHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/CodeCompleteHandler.scala
@@ -48,8 +48,8 @@ class CodeCompleteHandler(actorLoader: ActorLoader)
     val codeCompleteFuture = ask(interpreterActor, cr).mapTo[(Int, List[String])]
     codeCompleteFuture.onComplete {
       case Success(tuple) =>
-        val reply = CompleteReplyOk(tuple._2, cr.cursor_pos,
-                                    tuple._1, Metadata())
+        val reply = CompleteReplyOk(tuple._2, tuple._1,
+                                    cr.cursor_pos, Metadata())
         val completeReplyType = MessageType.Outgoing.CompleteReply.toString
         logKernelMessageAction("Sending code complete reply for", km)
         actorLoader.load(SystemActorType.KernelMessageRelay) !


### PR DESCRIPTION
The start and end positions were swapped, causing the front-ends to
replace no characters from the partial symbol that is completed.