### PR TITLE
TOREE-363: Fix Scala syntax highlighting.

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/Interpreter.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/Interpreter.scala
@@ -27,7 +27,9 @@ case class LanguageInfo(
                  name: String,
                  version: String,
                  fileExtension: Option[String] = None,
-                 pygmentsLexer: Option[String] = None) {
+                 pygmentsLexer: Option[String] = None,
+                 mimeType: Option[String] = None,
+                 codemirrorMode: Option[String] = None) {
 }
 
 trait Interpreter {

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/HandlerInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/HandlerInitialization.scala
@@ -162,7 +162,9 @@ trait StandardHandlerInitialization extends HandlerInitialization {
       name=langInfo.name,
       version=langInfo.version,
       file_extension=langInfo.fileExtension,
-      pygments_lexer=langInfo.pygmentsLexer)
+      pygments_lexer=langInfo.pygmentsLexer,
+      mimetype=langInfo.mimeType,
+      codemirror_mode=langInfo.codemirrorMode)
 
     //  These are the handlers for messages coming into the
     initializeRequestHandler(classOf[ExecuteRequestHandler],

--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/LanguageInfo.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/LanguageInfo.scala
@@ -21,5 +21,7 @@ case class LanguageInfo(
                  name: String,
                  version: String,
                  file_extension: Option[String] = None,
-                 pygments_lexer: Option[String] = None) {
+                 pygments_lexer: Option[String] = None,
+                 mimetype: Option[String] = None,
+                 codemirror_mode: Option[String] = None) {
 }

--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -168,6 +168,8 @@ class PySparkInterpreter(
       "python",
       version = version,
       fileExtension = Some(".py"),
-      pygmentsLexer = Some("python"))
+      pygmentsLexer = Some("python"),
+      mimeType = Some("text/x-ipython"),
+      codemirrorMode = Some("text/x-ipython"))
   }
 }

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -323,7 +323,12 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
   /**
     * Returns the language metadata for syntax highlighting
     */
-  override def languageInfo = LanguageInfo("scala", BuildInfo.scalaVersion, fileExtension = Some(".scala"))
+  override def languageInfo = LanguageInfo(
+    "scala", BuildInfo.scalaVersion,
+    fileExtension = Some(".scala"),
+    pygmentsLexer = Some("scala"),
+    mimeType = Some("text/x-scala"),
+    codemirrorMode = Some("text/x-scala"))
 }
 
 object ScalaInterpreter {

--- a/sparkr-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sparkr/SparkRInterpreter.scala
+++ b/sparkr-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sparkr/SparkRInterpreter.scala
@@ -150,7 +150,12 @@ class SparkRInterpreter(
       "-e",
       "cat(R.version$major, '.', R.version$minor, sep='', fill=TRUE)").!!
 
-    LanguageInfo("R", version = version, fileExtension = Some(".R"), pygmentsLexer = Some("r"))
+    LanguageInfo(
+      "R", version = version,
+      fileExtension = Some(".R"),
+      pygmentsLexer = Some("r"),
+      mimeType = Some("text/x-rsrc"),
+      codemirrorMode = Some("text/x-rsrc"))
   }
 
 }

--- a/sql-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sql/SqlInterpreter.scala
+++ b/sql-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/sql/SqlInterpreter.scala
@@ -107,6 +107,11 @@ class SqlInterpreter() extends Interpreter {
   // Unsupported
   override def doQuietly[T](body: => T): T = ???
 
-  override def languageInfo = LanguageInfo("sql", BuildInfo.sparkVersion, fileExtension = Some(".sql"), pygmentsLexer = Some("sql"))
+  override def languageInfo = LanguageInfo(
+    "sql", BuildInfo.sparkVersion,
+    fileExtension = Some(".sql"),
+    pygmentsLexer = Some("sql"),
+    mimeType = Some("text/x-sql"),
+    codemirrorMode = Some("text/x-sql"))
 
 }


### PR DESCRIPTION
This fixes Scala syntax highlighting in Jupyter notebooks. The kernel info reply needs to include a value for "codemirror_mode" that is recognized by CodeMirror. From looking at `CodeMirror.mimeModes` in the console, the correct one for Scala is `text/x-scala`. This also adds the mime type and uses the same value.