### PR TITLE
[TOREE-386] Overridable application name

### DIFF
--- a/etc/bin/run.sh
+++ b/etc/bin/run.sh
@@ -42,4 +42,11 @@ then
    TOREE_OPTS=${__TOREE_OPTS__}
 fi
 
-eval exec "${SPARK_HOME}/bin/spark-submit" "${SPARK_OPTS}" --class org.apache.toree.Main "${TOREE_ASSEMBLY}" "${TOREE_OPTS}" "$@"
+eval exec \
+     "${SPARK_HOME}/bin/spark-submit" \
+     --name "Apache Toree"
+     "${SPARK_OPTS}" \
+     --class org.apache.toree.Main \
+     "${TOREE_ASSEMBLY}" \
+     "${TOREE_OPTS}" \
+     "$@"

--- a/kernel-api/src/main/scala/org/apache/toree/kernel/api/KernelLike.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/kernel/api/KernelLike.scala
@@ -31,7 +31,7 @@ trait KernelLike {
 
   def createSparkContext(conf: SparkConf): SparkContext
 
-  def createSparkContext(master: String, appName: String): SparkContext
+  def createSparkContext(master: String): SparkContext
 
   /**
    * Executes a block of code represented as a string and returns the result.

--- a/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
@@ -40,7 +40,6 @@ class KernelBootstrap(config: Config) extends LogLike {
   this: BareInitialization with ComponentInitialization
     with HandlerInitialization with HookInitialization =>
 
-  private val DefaultAppName                    = SparkKernelInfo.banner
   private val DefaultActorSystemName            = "spark-kernel-actor-system"
 
   private var actorSystem: ActorSystem          = _
@@ -100,7 +99,6 @@ class KernelBootstrap(config: Config) extends LogLike {
       magicManager, pluginManager, responseMap) =
       initializeComponents(
         config      = config,
-        appName     = DefaultAppName,
         actorLoader = actorLoader
       )
     this.interpreters ++= Seq(interpreter)

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
@@ -49,7 +49,7 @@ trait ComponentInitialization {
    * @param actorLoader The actor loader to use for some initialization
    */
   def initializeComponents(
-    config: Config, appName: String, actorLoader: ActorLoader
+    config: Config, actorLoader: ActorLoader
   ): (CommStorage, CommRegistrar, CommManager, Interpreter,
     Kernel, DependencyDownloader, MagicManager, PluginManager,
     collection.mutable.Map[String, ActorRef])
@@ -65,11 +65,10 @@ trait StandardComponentInitialization extends ComponentInitialization {
    * Initializes and registers all components (not needed by bare init).
    *
    * @param config The config used for initialization
-   * @param appName The name of the "application" for Spark
    * @param actorLoader The actor loader to use for some initialization
    */
   def initializeComponents(
-    config: Config, appName: String, actorLoader: ActorLoader
+    config: Config, actorLoader: ActorLoader
   ) = {
     val (commStorage, commRegistrar, commManager) =
       initializeCommObjects(actorLoader)
@@ -84,7 +83,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
 
     initializePlugins(config, pluginManager)
 
-    initializeSparkContext(config, kernel, appName)
+    initializeSparkContext(config, kernel)
 
     interpreterManager.initializeInterpreters(kernel)
     
@@ -99,9 +98,9 @@ trait StandardComponentInitialization extends ComponentInitialization {
   }
 
 
-  def initializeSparkContext(config:Config, kernel:Kernel, appName:String) = {
+  def initializeSparkContext(config:Config, kernel:Kernel) = {
     if(!config.getBoolean("nosparkcontext")) {
-      kernel.createSparkContext(config.getString("spark.master"), appName)
+      kernel.createSparkContext(config.getString("spark.master"))
     }
   }
 

--- a/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
@@ -358,9 +358,9 @@ class Kernel (
   }
 
   override def createSparkContext(
-    master: String, appName: String
+    master: String
   ): SparkContext = {
-    createSparkContext(new SparkConf().setMaster(master).setAppName(appName))
+    createSparkContext(new SparkConf().setMaster(master))
   }
 
   // TODO: Think of a better way to test without exposing this


### PR DESCRIPTION
The application name of Toree's Spark driver program is currenlty
hardcoded to "Apache Toree" in the Spark context initialization
functions. By moving the name to a parameter into the launcher script,
it is possible for users to override the name by specifying an
additional "--name" parameter in the SPARK_OPTS variable (this is
because later parameters override earlier ones).