### PR TITLE
Fix: quote application name

### DIFF
--- a/etc/bin/run.sh
+++ b/etc/bin/run.sh
@@ -44,7 +44,7 @@ fi
 
 eval exec \
      "${SPARK_HOME}/bin/spark-submit" \
-     --name "Apache Toree" \
+     --name "'Apache Toree'" \
      "${SPARK_OPTS}" \
      --class org.apache.toree.Main \
      "${TOREE_ASSEMBLY}" \


### PR DESCRIPTION
Thanks to @paulovn who discovered and fixed this bug https://github.com/apache/incubator-toree/commit/0eb3bb29fbe5fb533bc9b4bbb720a59362982b30.

As a more general question, do we want to keep the `eval` here? To my understanding, it lets the options contain env variables that will get expanded when toree is started. In a shell environment these options will get expanded anyway and I'm not sure if it is safe to evaluate parameters in general.