### PR TITLE
Distinguish between shutdown request and System.exit from cell

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/security/KernelSecurityManager.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/security/KernelSecurityManager.scala
@@ -60,7 +60,7 @@ object KernelSecurityManager {
    * cases that don't exist in the normal name conventions.
    *
    * @param name The name of the permission
-   *:
+   *
    * @return True if the permission is to be checked, false otherwise
    */
   private def shouldCheckPermissionSpecialCases(name: String): Boolean =

--- a/kernel-api/src/main/scala/org/apache/toree/security/KernelSecurityManager.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/security/KernelSecurityManager.scala
@@ -26,6 +26,11 @@ object KernelSecurityManager {
   val RestrictedGroupName = "restricted-" + UUID.randomUUID().toString
 
   /**
+    * ThreadLocal to indicate that an exit from a restricted group thread is permitted.
+    */
+  private val tlEnableRestrictedExit:ThreadLocal[Boolean] = new ThreadLocal[Boolean]
+
+  /**
    * Special case for this permission since the name changes with each status
    * code.
    */
@@ -55,11 +60,22 @@ object KernelSecurityManager {
    * cases that don't exist in the normal name conventions.
    *
    * @param name The name of the permission
-   *
+   *:
    * @return True if the permission is to be checked, false otherwise
    */
   private def shouldCheckPermissionSpecialCases(name: String): Boolean =
     name.startsWith(SystemExitPermissionName)
+
+  /**
+    * Sets tlEnableRestrictedExit to true if caller is in the restricted group.  This
+    * method is intended to be called exclusively from the ShutdownHandler since that's
+    * the only path by which we should permit System.exit to succeed within the notebook.
+    * Note that dual SIGINTs occur from a non-restricted thread group and are also permitted.
+    */
+  def enableRestrictedExit() {
+    val currentGroup = Thread.currentThread().getThreadGroup
+    tlEnableRestrictedExit.set(currentGroup.getName == RestrictedGroupName)
+  }
 }
 
 class KernelSecurityManager extends SecurityManager {
@@ -117,10 +133,21 @@ class KernelSecurityManager extends SecurityManager {
   override def checkExit(status: Int): Unit = {
     val currentGroup = Thread.currentThread().getThreadGroup
 
-    if (currentGroup.getName == RestrictedGroupName) {
-      // TODO: Determine why System.exit(...) is being blocked in the ShutdownHandler
-      System.out.println("Unauthorized system.exit detected!")
-      //throw new SecurityException("Not allowed to invoke System.exit!")
+    // Exit will be denied if this thread is in the restricted group AND the restricted
+    // exit thread-local has not been enabled.  This will only happen when the request
+    // came from jupyter via a (cell) execution_request indicating the cell is attempting
+    // an exit call.  Proper notebook shutdown requests will go through the ShutdownHandler
+    // where restricted exits are enabled and SIGINT (ctrl-c) requests are not performed
+    // via the restricted group and thus allowed.
+    //
+    if (currentGroup.getName == RestrictedGroupName ) {
+      val isRestrictedExitEnabled:Option[Boolean] = Some(tlEnableRestrictedExit.get())
+
+      if ( !isRestrictedExitEnabled.getOrElse(false) ) {
+        throw new SecurityException("Not allowed to invoke System.exit!")
+      }
     }
+    // Just in case this thread remains alive - force it to pass through ShutdownHandler
+    tlEnableRestrictedExit.set(false)
   }
 }

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
@@ -21,7 +21,9 @@ import org.apache.toree.comm.{CommRegistrar, CommStorage, KernelCommWriter}
 import org.apache.toree.kernel.protocol.v5.content.{ShutdownReply, ShutdownRequest, CommOpen}
 import org.apache.toree.kernel.protocol.v5.kernel.{ActorLoader, Utilities}
 import org.apache.toree.kernel.protocol.v5._
+import org.apache.toree.security.KernelSecurityManager
 import org.apache.toree.utils.MessageLogSupport
+
 import play.api.data.validation.ValidationError
 import play.api.libs.json.JsPath
 
@@ -56,10 +58,13 @@ class ShutdownHandler(
       .withParent(kernelMessage)
       .withContentString(shutdownReply).build
 
-    logger.debug("Attempting graceful shutdown.")
     actorLoader.load(SystemActorType.KernelMessageRelay) ! kernelResponseMessage
+
+    // Instruct security manager that exit should be allowed
+    KernelSecurityManager.enableRestrictedExit()
+
     System.exit(0)
-  }
+   }
 
 }
 

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
@@ -23,7 +23,6 @@ import org.apache.toree.kernel.protocol.v5.kernel.{ActorLoader, Utilities}
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.security.KernelSecurityManager
 import org.apache.toree.utils.MessageLogSupport
-
 import play.api.data.validation.ValidationError
 import play.api.libs.json.JsPath
 
@@ -58,6 +57,7 @@ class ShutdownHandler(
       .withParent(kernelMessage)
       .withContentString(shutdownReply).build
 
+    logger.debug("Attempting graceful shutdown.")
     actorLoader.load(SystemActorType.KernelMessageRelay) ! kernelResponseMessage
 
     // Instruct security manager that exit should be allowed

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
@@ -64,7 +64,7 @@ class ShutdownHandler(
     KernelSecurityManager.enableRestrictedExit()
 
     System.exit(0)
-   }
+  }
 
 }
 


### PR DESCRIPTION
Prior to this change there were three ways the toree process could be exited via deliberate actions. 

1. The user could enter dual cntrl-c (or send SIGINT) signals within 3 seconds of each other 
2. The user could issue a formal shutdown request from Jupyter 
3. The user could execute a cell of a notebook containing System.exit(n) or its equivalent 

The first two use cases are considered valid and are permitted.  Use case three, however, should be prevented by design.

The issue being addressed is a conflict between the second and third cases since both of those cases occur within the same thread group (referred to as the restricted group).  Prior to this change, shutdown requests made via Jupyter (vs. System.exit from within a cell) were not distinguished from cell requests.  Since the former is processed by the ShutdownHandler while the latter is processed by the ExecuteRequestHandler the change is to set a thread-local residing in the KernelSecurityManager from the ShutdownHandler immediately prior to its invocation of System.exit(0).  The KernelSecurityManager.checkExit() method then consults the thread local to ensure this call came by way of the ShutdownHandler and allows the exit to take place.  If the thread-local has not been set or has a value of false and its within the restricted group, a security exception is thrown to deny the exit attempt.

This topic was briefly discussed on gitter: https://gitter.im/apache/toree?at=58b9a97200c00c3d4fb6799f