### PR TITLE
[TOREE-355] Enable Toree to run on Hadoop distributions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,6 +230,11 @@ scalacOptions in (ScalaUnidoc, unidoc) ++= Seq(
 libraryDependencies ++= Dependencies.sparkAll.value
 unmanagedResourceDirectories in Compile += { baseDirectory.value / "dist/toree-legal" }
 
+assemblyShadeRules in assembly := Seq(
+  ShadeRule.rename("org.clapper.classutil.**" -> "shadeclapper.@0").inAll,
+  ShadeRule.rename("org.objectweb.asm.**" -> "shadeasm.@0").inAll
+)
+
 test in assembly := {}
 assemblyOption in assembly := (assemblyOption in assembly).value.copy(includeScala = false)
 aggregate in assembly := false


### PR DESCRIPTION
Shade some dependencies around ASM and Clapper ClassUtil
that causes conflicts in Hadoop distributions that have
older versions of these dependencies.