### PR TITLE
[TOREE-395] disable cell result output from console

### DIFF
--- a/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
+++ b/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
@@ -57,8 +57,6 @@ class InterpreterActorSpecForIntegration extends TestKit(
 
   private val output = new ByteArrayOutputStream()
   private val interpreter = new ScalaInterpreter {
-    override protected val multiOutputStream = MultiOutputStream(List(mock[OutputStream], lastResultOut))
-
     override protected def bindKernelVariable(kernel: KernelLike): Unit = { }
   }
 

--- a/kernel/src/test/scala/integration/PostProcessorSpecForIntegration.scala
+++ b/kernel/src/test/scala/integration/PostProcessorSpecForIntegration.scala
@@ -35,9 +35,7 @@ class PostProcessorSpecForIntegration extends FunSpec with Matchers
   before {
     // TODO: Move instantiation and start of interpreter to a beforeAll
     //       for performance improvements
-    scalaInterpreter = new ScalaInterpreter {
-      override protected val multiOutputStream = MultiOutputStream(List(mock[OutputStream], lastResultOut))
-    }
+    scalaInterpreter = new ScalaInterpreter
 
     scalaInterpreter.init(mock[Kernel])
 

--- a/scala-interpreter/src/main/scala-2.10/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.10/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -303,7 +303,7 @@ trait ScalaInterpreterSpecific { this: ScalaInterpreter =>
     taskManager.start()
 
     sparkIMain =
-      newSparkIMain(settings, new JPrintWriter(multiOutputStream, true))
+      newSparkIMain(settings, new JPrintWriter(lastResultOut, true))
 
 
     //logger.debug("Initializing interpreter")

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -278,7 +278,7 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
     logger.debug("Initializing task manager")
     taskManager.start()
 
-    iMain = newIMain(settings, new JPrintWriter(multiOutputStream, true))
+    iMain = newIMain(settings, new JPrintWriter(lastResultOut, true))
 
     //logger.debug("Initializing interpreter")
     //iMain.initializeSynchronous()

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -48,7 +48,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
    protected val lastResultOut = new ByteArrayOutputStream()
 
-   protected val multiOutputStream = MultiOutputStream(List(Console.out, lastResultOut))
+   protected val multiOutputStream = lastResultOut
    private[scala] var taskManager: TaskManager = _
 
   /** Since the ScalaInterpreter can be started without a kernel, we need to ensure that we can compile things.

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -29,7 +29,7 @@ import org.apache.spark.repl.Main
 
 import org.apache.toree.interpreter._
 import org.apache.toree.kernel.api.{KernelLike, KernelOptions}
-import org.apache.toree.utils.{MultiOutputStream, TaskManager}
+import org.apache.toree.utils.TaskManager
 import org.slf4j.LoggerFactory
 import org.apache.toree.kernel.BuildInfo
 
@@ -48,7 +48,6 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
    protected val lastResultOut = new ByteArrayOutputStream()
 
-   protected val multiOutputStream = MultiOutputStream(List(lastResultOut))
    private[scala] var taskManager: TaskManager = _
 
   /** Since the ScalaInterpreter can be started without a kernel, we need to ensure that we can compile things.

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -48,7 +48,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
    protected val lastResultOut = new ByteArrayOutputStream()
 
-   protected val multiOutputStream = lastResultOut
+   protected val multiOutputStream = MultiOutputStream(List(lastResultOut))
    private[scala] var taskManager: TaskManager = _
 
   /** Since the ScalaInterpreter can be started without a kernel, we need to ensure that we can compile things.

--- a/scala-interpreter/src/test/scala/integration/interpreter/scala/AddExternalJarMagicSpecForIntegration.scala
+++ b/scala-interpreter/src/test/scala/integration/interpreter/scala/AddExternalJarMagicSpecForIntegration.scala
@@ -38,8 +38,6 @@ class AddExternalJarMagicSpecForIntegration
 
   before {
     interpreter = new ScalaInterpreter {
-      override protected val multiOutputStream = MultiOutputStream(List(mock[OutputStream], lastResultOut))
-
       override protected def bindKernelVariable(kernel: KernelLike): Unit = { }
     }
     // interpreter.start()


### PR DESCRIPTION
This issue - discussed in [TOREE-395](https://issues.apache.org/jira/browse/TOREE-395) (and somewhat in [TOREE-380](https://issues.apache.org/jira/browse/TOREE-380)) - essentially takes the appropriate portion of PR #104 and delivers it here.  This change makes the scala interpreter behave like other interpreters (and kernels) by not issuing the cell results to the console (where it is typically captured by the Jupyter logging) and could contain sensitive information.