### PR TITLE
[TOREE-397] Avoid hardcoding the deploy mode property

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/api/Kernel.scala
@@ -366,8 +366,13 @@ class Kernel (
   // TODO: Think of a better way to test without exposing this
   protected[toree] def createSparkConf(conf: SparkConf) = {
 
-    logger.info("Setting deployMode to client")
-    conf.set("spark.submit.deployMode", "client")
+    if(conf.contains("spark.submit.deployMode")) {
+      logger.info("Utilizing deploy mode: " + conf.get("spark.submit.deployMode"))
+    } else {
+      logger.info("Setting deployMode to client")
+      conf.set("spark.submit.deployMode", "client")
+    }
+
     conf
   }
 


### PR DESCRIPTION
By checking if a proper spark.submit.deployMode property
is available in the sparkConf enables choosing the deploy
mode by using system properties such as $SPARK_OPTS.

This change continues to use client mode if no configuration
was provided.