### PR TITLE
Allow also URLs with additional parameters

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/magic/builtin/AddJar.scala
+++ b/kernel/src/main/scala/org/apache/toree/magic/builtin/AddJar.scala
@@ -67,11 +67,16 @@ class AddJar
    * @param location The remote location (URL) 
    * @return The name of the remote URL, or an empty string if one does not exist
    */
-  def getFileFromLocation(location: String): String = {
+   def getFileFromLocation(location: String): String = {
     val url = new URL(location)
     val file = url.getFile.split("/")
     if (file.length > 0) {
-        file.last
+        if ( file.last.contains('?') ) {
+          file.last.split('?')(0)
+        }
+        else { 
+          file.last
+        }  
     } else {
         ""
     }
@@ -104,7 +109,7 @@ class AddJar
     val jarName = getFileFromLocation(jarRemoteLocation)
 
     // Ensure the URL actually contains a jar or zip file
-    if (!jarName.endsWith(".jar") && !jarName.endsWith(".zip")) {
+    if (!jarName.contains(".jar") && !jarName.contains(".zip")) {
         throw new IllegalArgumentException(
           s"The jar file $jarName must end in .jar or .zip."
         )


### PR DESCRIPTION
Not all URLs end with JAR or ZIP, e.g., if we load content from an HTTPFS Service.

Examples for testing: (a,c,d work as expeced) (b => more logic needed to create a JAR name from this URL)

import java.io.{File, PrintStream}
import java.net.URL
import java.nio.file.{Files, Paths}

def getFileFromLocation(location: String): String = {
    val url = new URL(location)
    val file = url.getFile.split("/")
    if (file.length > 0) {
        if ( file.last.contains('?') ) {
          file.last.split('?')(0)
        }
        else { 
          file.last
        }  
    } else {
        ""
    }
  }

val fnA = "http://cdsw-mk4-1.gce.cloudera.com:8888/filebrowser/download=/user/systest/TOOLBOX/SparkShellUtilities.jar?user.name=123"
val a = getFileFromLocation(fnA)
a
  
val fnB = "https://oss.sonatype.org/service/local/artifact/maven/content?r=snapshots&g=org.gephi&a=gephi-toolkit&v=0.9.2-SNAPSHOT&c=all"
val b = getFileFromLocation(fnB)
b

val fnC = "http://cdsw-mk4-1.gce.cloudera.com:8888/filebrowser/download=/user/systest/TOOLBOX/SparkShellUtilities.jar"
val c = getFileFromLocation(fnC)
c
  
val fnD = "http://cdsw-mk4-1.gce.cloudera.com:8888/filebrowser/download=/user/systest/TOOLBOX/SparkShellUtilities.jar?user.name=123&doas=123456"
val d = getFileFromLocation(fnD)
d