### PR TITLE
TOREE-412: Update AddDeps magic

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -123,9 +123,9 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     val resolution = start.process.run(fetch).unsafePerformSync
 
     // Report any resolution errors
-    val errors: Seq[((Module, String), Seq[String])] = resolution.metadataErrors
-    errors.foreach { case (d, e) =>
-      printStream.println(s"-> Failed to resolve ${d._1.toString()}:${d._2}")
+    val errors: Seq[(Dependency, Seq[String])] = resolution.errors
+    errors.foreach { case (dep, e) =>
+      printStream.println(s"-> Failed to resolve ${dep.module}:${dep.version}")
       e.foreach(s => printStream.println(s"    -> $s"))
     }
 

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -123,9 +123,9 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     val resolution = start.process.run(fetch).unsafePerformSync
 
     // Report any resolution errors
-    val errors: Seq[(Dependency, Seq[String])] = resolution.errors
-    errors.foreach { case (dep, e) =>
-      printStream.println(s"-> Failed to resolve ${dep.module}:${dep.version}")
+    val errors: Seq[((Module, String), Seq[String])] = resolution.metadataErrors
+    errors.foreach { case ((module, version), e) =>
+      printStream.println(s"-> Failed to resolve ${module.toString()}:$version")
       e.foreach(s => printStream.println(s"    -> $s"))
     }
 

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -73,6 +73,7 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     extraRepositories: Seq[(URL, Option[Credentials])] = Nil,
     verbose: Boolean,
     trace: Boolean,
+    configuration: Option[String] = None,
     artifactType: Option[String] = None,
     artifactClassifier: Option[String] = None
   ): Seq[URI] = {
@@ -91,7 +92,7 @@ class CoursierDependencyDownloader extends DependencyDownloader {
         version = version,
         transitive = transitive,
         exclusions = exclusions, // NOTE: Source/Javadoc not downloaded by default
-        configuration = "default",
+        configuration = configuration.getOrElse("default"),
         attributes = Attributes(
           artifactType.getOrElse(""),
           artifactClassifier.getOrElse("")

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -72,7 +72,9 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     ignoreResolutionErrors: Boolean,
     extraRepositories: Seq[(URL, Option[Credentials])] = Nil,
     verbose: Boolean,
-    trace: Boolean
+    trace: Boolean,
+    artifactType: Option[String] = None,
+    artifactClassifier: Option[String] = None
   ): Seq[URI] = {
     assert(localDirectory != null)
     import coursier._
@@ -89,7 +91,11 @@ class CoursierDependencyDownloader extends DependencyDownloader {
         version = version,
         transitive = transitive,
         exclusions = exclusions, // NOTE: Source/Javadoc not downloaded by default
-        configuration = "default"
+        configuration = "default",
+        attributes = Attributes(
+          artifactType.getOrElse(""),
+          artifactClassifier.getOrElse("")
+        )
       )
     ))
 

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -88,7 +88,8 @@ class CoursierDependencyDownloader extends DependencyDownloader {
         module = Module(organization = groupId, name = artifactId),
         version = version,
         transitive = transitive,
-        exclusions = exclusions // NOTE: Source/Javadoc not downloaded by default
+        exclusions = exclusions, // NOTE: Source/Javadoc not downloaded by default
+        configuration = "default"
       )
     ))
 

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
@@ -54,7 +54,9 @@ abstract class DependencyDownloader {
     ignoreResolutionErrors: Boolean = true,
     extraRepositories: Seq[(URL, Option[Credentials])] = Nil,
     verbose: Boolean = false,
-    trace: Boolean = false
+    trace: Boolean = false,
+    artifactType: Option[String] = None,
+    artifactClassifier: Option[String] = None
   ): Seq[URI]
 
   /**

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/DependencyDownloader.scala
@@ -55,6 +55,7 @@ abstract class DependencyDownloader {
     extraRepositories: Seq[(URL, Option[Credentials])] = Nil,
     verbose: Boolean = false,
     trace: Boolean = false,
+    configuration: Option[String] = None,
     artifactType: Option[String] = None,
     artifactClassifier: Option[String] = None
   ): Seq[URI]

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
@@ -92,6 +92,7 @@ class IvyDependencyDownloader(
     extraRepositories: Seq[(URL, Option[Credentials])] = Nil,
     verbose: Boolean,
     trace: Boolean,
+    configuration: Option[String] = None,
     artifactType: Option[String] = None,
     artifactClassifier: Option[String] = None
   ): Seq[URI] = {

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
@@ -91,7 +91,9 @@ class IvyDependencyDownloader(
     ignoreResolutionErrors: Boolean,
     extraRepositories: Seq[(URL, Option[Credentials])] = Nil,
     verbose: Boolean,
-    trace: Boolean
+    trace: Boolean,
+    artifactType: Option[String] = None,
+    artifactClassifier: Option[String] = None
   ): Seq[URI] = {
     // Start building the ivy.xml file
     val ivyFile = File.createTempFile("ivy-custom", ".xml")

--- a/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
+++ b/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
@@ -60,6 +60,10 @@ class AddDeps extends LineMagic with IncludeInterpreter
     "credential", "Adds a credential file to be used to the list"
   ).withRequiredArg().ofType(classOf[String])
 
+  private val _configuration = parser.accepts(
+    "ivy-configuration", "Sets the Ivy configuration for the dependency; defaults to \"default\""
+  ).withRequiredArg().ofType(classOf[String])
+
   private val _classifier = parser.accepts(
     "classifier", "Sets the dependency's classifier"
   ).withRequiredArg().ofType(classOf[String])
@@ -91,6 +95,7 @@ class AddDeps extends LineMagic with IncludeInterpreter
         extraRepositories       = repositoriesWithCreds,
         verbose                 = _verbose,
         trace                   = _trace,
+        configuration           = get(_configuration),
         artifactClassifier      = get(_classifier)
       )
 

--- a/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
+++ b/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
@@ -60,6 +60,10 @@ class AddDeps extends LineMagic with IncludeInterpreter
     "credential", "Adds a credential file to be used to the list"
   ).withRequiredArg().ofType(classOf[String])
 
+  private val _classifier = parser.accepts(
+    "classifier", "Sets the dependency's classifier"
+  ).withRequiredArg().ofType(classOf[String])
+
   /**
    * Execute a magic representing a line magic.
    *
@@ -86,7 +90,8 @@ class AddDeps extends LineMagic with IncludeInterpreter
         ignoreResolutionErrors  = !_abortOnResolutionErrors,
         extraRepositories       = repositoriesWithCreds,
         verbose                 = _verbose,
-        trace                   = _trace
+        trace                   = _trace,
+        artifactClassifier      = get(_classifier)
       )
 
       // pass the new Jars to the kernel

--- a/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
+++ b/kernel/src/main/scala/org/apache/toree/magic/builtin/AddDeps.scala
@@ -90,7 +90,7 @@ class AddDeps extends LineMagic with IncludeInterpreter
       )
 
       // pass the new Jars to the kernel
-      kernel.addJars(uris:_*)
+      kernel.addJars(uris.filter(_.getPath.endsWith(".jar")): _*)
     } else {
       printHelp(printStream, """%AddDeps my.company artifact-id version""")
     }

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -18,7 +18,6 @@
 package org.apache.toree.kernel.interpreter.scala
 
 import java.io.ByteArrayOutputStream
-import java.nio.charset.Charset
 import java.util.concurrent.{ExecutionException, TimeoutException, TimeUnit}
 import com.typesafe.config.{Config, ConfigFactory}
 import jupyter.Displayers

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -93,15 +93,19 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
      settings = appendClassPath(settings)
 
      start()
-     bindKernelVariable(kernel)
 
      // ensure bindings are defined before allowing user code to run
-     bindSparkSession()
-     bindSparkContext()
-     defineImplicits()
+     bindVariables()
 
      this
    }
+
+  protected def bindVariables(): Unit = {
+    bindKernelVariable(kernel)
+    bindSparkSession()
+    bindSparkContext()
+    defineImplicits()
+  }
 
    protected[scala] def buildClasspath(classLoader: ClassLoader): String = {
 
@@ -367,7 +371,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
     doQuietly(interpret(code))
   }
 
-   override def classLoader: ClassLoader = _runtimeClassloader
+  override def classLoader: ClassLoader = _runtimeClassloader
 
   /**
     * Returns the language metadata for syntax highlighting


### PR DESCRIPTION
* Removes non-Jar files (POM files) from downloaded artifacts before adding dependencies to the kernel
* Updates to Coursier 1.0.0-M15-7
* Uses "default" configuration by default, instead of "compile" for Ivy dependencies
* Adds `--classifier` for maven artifacts
* Adds `--ivy-configuration` for Ivy artifacts