### PR TITLE
TOREE-413: Add exit commands and kernel idle timeout.

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/interpreter/InterpreterTypes.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/interpreter/InterpreterTypes.scala
@@ -25,4 +25,6 @@ object InterpreterTypes {
    * Represents the output from an interpret execution.
    */
   type ExecuteOutput = Map[String, String]
+
+  case class InterpreterShutdownRequest()
 }

--- a/kernel-api/src/main/scala/org/apache/toree/kernel/api/KernelLike.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/kernel/api/KernelLike.scala
@@ -91,6 +91,11 @@ trait KernelLike {
   def in: InputStream
 
   /**
+    * Requests that the kernel shut down.
+    */
+  def shutdown(): Unit
+
+  /**
    * Represents data to be shared using the kernel as the middleman.
    *
    * @note Using Java structure to enable other languages to have easy access!

--- a/kernel/src/main/scala/org/apache/toree/boot/CommandLineOptions.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/CommandLineOptions.scala
@@ -100,6 +100,10 @@ class CommandLineOptions(args: Seq[String]) {
     "interpreter-plugin"
   ).withRequiredArg().ofType(classOf[String])
 
+  private val _idle_timeout = parser.accepts(
+    "idle-timeout"
+  ).withRequiredArg().ofType(classOf[String])
+
   private val options = parser.parse(args.map(_.trim): _*)
 
   /*
@@ -156,8 +160,8 @@ class CommandLineOptions(args: Seq[String]) {
       "default_repositories" -> getAll(_default_repositories).map(_.asJava)
         .flatMap(list => if (list.isEmpty) None else Some(list)),
       "default_repository_credentials" -> getAll(_default_repository_credentials).map(_.asJava)
-          .flatMap(list => if (list.isEmpty) None else Some(list))
-
+          .flatMap(list => if (list.isEmpty) None else Some(list)),
+      "idle_timeout" -> get(_idle_timeout)
     ).flatMap(removeEmptyOptions).asInstanceOf[Map[String, AnyRef]].asJava)
 
     commandLineConfig.withFallback(profileConfig).withFallback(ConfigFactory.load)

--- a/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
@@ -99,7 +99,8 @@ class KernelBootstrap(config: Config) extends LogLike {
       magicManager, pluginManager, responseMap) =
       initializeComponents(
         config      = config,
-        actorLoader = actorLoader
+        actorLoader = actorLoader,
+        requestShutdown = shutdown()
       )
     this.interpreters ++= Seq(interpreter)
 

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/ComponentInitialization.scala
@@ -48,7 +48,7 @@ trait ComponentInitialization {
    * @param actorLoader The actor loader to use for some initialization
    */
   def initializeComponents(
-    config: Config, actorLoader: ActorLoader
+    config: Config, actorLoader: ActorLoader, requestShutdown: => Unit
   ): (CommStorage, CommRegistrar, CommManager, Interpreter,
     Kernel, DependencyDownloader, MagicManager, PluginManager,
     collection.mutable.Map[String, ActorRef])
@@ -67,7 +67,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
    * @param actorLoader The actor loader to use for some initialization
    */
   def initializeComponents(
-    config: Config, actorLoader: ActorLoader
+    config: Config, actorLoader: ActorLoader, requestShutdown: => Unit
   ) = {
     val (commStorage, commRegistrar, commManager) =
       initializeCommObjects(actorLoader)
@@ -78,7 +78,7 @@ trait StandardComponentInitialization extends ComponentInitialization {
     val dependencyDownloader = initializeDependencyDownloader(config)
     val pluginManager = createPluginManager(config, interpreterManager, dependencyDownloader)
 
-    val kernel = initializeKernel(config, actorLoader, interpreterManager, commManager, pluginManager)
+    val kernel = initializeKernel(config, actorLoader, interpreterManager, commManager, pluginManager, requestShutdown)
 
     initializePlugins(config, pluginManager)
 
@@ -144,7 +144,8 @@ trait StandardComponentInitialization extends ComponentInitialization {
     actorLoader: ActorLoader,
     interpreterManager: InterpreterManager,
     commManager: CommManager,
-    pluginManager: PluginManager
+    pluginManager: PluginManager,
+    requestShutdown: => Unit
   ) = {
 
     //kernel has a dependency on ScalaInterpreter to get the ClassServerURI for the SparkConf
@@ -157,7 +158,8 @@ trait StandardComponentInitialization extends ComponentInitialization {
       actorLoader,
       interpreterManager,
       commManager,
-      pluginManager
+      pluginManager,
+      requestShutdown
     ){
       override protected[toree] def createSparkConf(conf: SparkConf) = {
         val theConf = super.createSparkConf(conf)

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/HandlerInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/HandlerInitialization.scala
@@ -89,18 +89,18 @@ trait StandardHandlerInitialization extends HandlerInitialization {
       actorSystem, actorLoader, interpreter, kernel, commRegistrar, commStorage, responseMap
     )
     initializeSystemActors(
-      actorSystem, actorLoader, interpreter, pluginManager, magicManager
+      actorSystem, actorLoader, kernel, interpreter, pluginManager, magicManager
     )
   }
 
   private def initializeSystemActors(
     actorSystem: ActorSystem, actorLoader: ActorLoader,
-    interpreter: Interpreter, pluginManager: PluginManager,
-    magicManager: MagicManager
+    kernel: Kernel, interpreter: Interpreter,
+    pluginManager: PluginManager, magicManager: MagicManager
   ): Unit = {
     logger.debug("Creating interpreter actor")
     val interpreterActor = actorSystem.actorOf(
-      Props(classOf[InterpreterActor], new InterpreterTaskFactory(interpreter)),
+      Props(classOf[InterpreterActor], new InterpreterTaskFactory(kernel, interpreter)),
       name = SystemActorType.Interpreter.toString
     )
 

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
@@ -17,15 +17,11 @@
 
 package org.apache.toree.kernel.protocol.v5.handler
 
-import org.apache.toree.comm.{CommRegistrar, CommStorage, KernelCommWriter}
-import org.apache.toree.kernel.protocol.v5.content.{ShutdownReply, ShutdownRequest, CommOpen}
-import org.apache.toree.kernel.protocol.v5.kernel.{ActorLoader, Utilities}
 import org.apache.toree.kernel.protocol.v5._
+import org.apache.toree.kernel.protocol.v5.content.ShutdownReply
+import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.security.KernelSecurityManager
 import org.apache.toree.utils.MessageLogSupport
-import play.api.data.validation.ValidationError
-import play.api.libs.json.JsPath
-
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.Future
 
@@ -62,6 +58,8 @@ class ShutdownHandler(
 
     // Instruct security manager that exit should be allowed
     KernelSecurityManager.enableRestrictedExit()
+
+    Thread.sleep(100) // wait for the queued response to be sent before exiting
 
     System.exit(0)
   }

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
@@ -45,7 +45,7 @@ class ExecuteRequestTaskActor(
   @volatile private var lastExecuteRequest: Long = System.currentTimeMillis
 
   override def preStart(): Unit = {
-    shutdownMonitorTaskId = if (kernel.config.hasPath("idle_timeout")) {
+    shutdownMonitorTaskId = if (kernel.config != null && kernel.config.hasPath("idle_timeout")) {
       val timeoutMs = kernel.config.getDuration("idle_timeout", TimeUnit.MILLISECONDS)
       Some(global.ScheduledTaskManager.instance.addTask(timeInterval = 30000, task = {
         val now = System.currentTimeMillis

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
@@ -50,7 +50,9 @@ class ExecuteRequestTaskActor(
       Some(global.ScheduledTaskManager.instance.addTask(timeInterval = 30000, task = {
         val now = System.currentTimeMillis
         if (!interpreterRunning && (System.currentTimeMillis - lastExecuteRequest > timeoutMs)) {
-          logger.info(s"No execution requests in ${timeoutMs / 1000} seconds, shutting down.")
+          val msg = s"No execution requests in ${timeoutMs / 1000} seconds, shutting down."
+          println(msg)
+          logger.info(msg)
           kernel.shutdown()
         }
       }))

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActor.scala
@@ -18,86 +18,133 @@
 package org.apache.toree.kernel.protocol.v5.interpreter.tasks
 
 import java.io.OutputStream
-
+import java.util.concurrent.TimeUnit
 import akka.actor.{Actor, Props}
+import org.apache.toree.global
 import org.apache.toree.global.StreamState
 import org.apache.toree.interpreter.{ExecuteAborted, ExecuteError, Interpreter, Results}
+import org.apache.toree.kernel.api.KernelLike
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
 import org.apache.toree.security.KernelSecurityManager
 import org.apache.toree.utils.{ConditionalOutputStream, LogLike, MultiOutputStream}
 
 object ExecuteRequestTaskActor {
-  def props(interpreter: Interpreter): Props =
-    Props(classOf[ExecuteRequestTaskActor], interpreter)
+  def props(kernel: KernelLike, interpreter: Interpreter): Props =
+    Props(classOf[ExecuteRequestTaskActor], kernel, interpreter)
 }
 
-class ExecuteRequestTaskActor(interpreter: Interpreter) extends Actor with LogLike {
+class ExecuteRequestTaskActor(
+    kernel: KernelLike,
+    interpreter: Interpreter) extends Actor with LogLike {
+
   require(interpreter != null)
+
+  private var shutdownMonitorTaskId: Option[String] = None
+  @volatile private var interpreterRunning: Boolean = false
+  @volatile private var lastExecuteRequest: Long = System.currentTimeMillis
+
+  override def preStart(): Unit = {
+    shutdownMonitorTaskId = if (kernel.config.hasPath("idle_timeout")) {
+      val timeoutMs = kernel.config.getDuration("idle_timeout", TimeUnit.MILLISECONDS)
+      Some(global.ScheduledTaskManager.instance.addTask(timeInterval = 30000, task = {
+        val now = System.currentTimeMillis
+        if (!interpreterRunning && (System.currentTimeMillis - lastExecuteRequest > timeoutMs)) {
+          logger.info(s"No execution requests in ${timeoutMs / 1000} seconds, shutting down.")
+          kernel.shutdown()
+        }
+      }))
+    } else {
+      None
+    }
+  }
+
+  override def postStop(): Unit = {
+    shutdownMonitorTaskId match {
+      case Some(taskId) =>
+        global.ScheduledTaskManager.instance.removeTask(taskId)
+        shutdownMonitorTaskId = None
+      case _ =>
+    }
+  }
 
   override def receive: Receive = {
     case (executeRequest: ExecuteRequest, parentMessage: KernelMessage,
       outputStream: OutputStream) =>
       // If the cell is not empty, then interpret.
-      if(executeRequest.code.trim != "") {
-        //interpreter.updatePrintStreams(System.in, outputStream, outputStream)
-        val newInputStream = System.in
-        val newOutputStream = buildOutputStream(outputStream, System.out)
-        val newErrorStream = buildOutputStream(outputStream, System.err)
+      executeRequest.code.trim match {
+        case "quit" | "exit" | ":q" =>
+          kernel.shutdown()
+          sender ! Left(Map.empty)
 
-        // Update our global streams to be used by future output
-        // NOTE: This is not async-safe! This is expected to be broken when
-        //       running asynchronously! Use an alternative for data
-        //       communication!
-        StreamState.setStreams(newInputStream, newOutputStream, newErrorStream)
+        case "" =>
+          lastExecuteRequest = System.currentTimeMillis
+          // If we get empty code from a cell then just return ExecuteReplyOk
+          sender ! Left(Map.empty)
 
-        val (success, result) = {
+        case _ =>
+          interpreterRunning = true
+
+          //interpreter.updatePrintStreams(System.in, outputStream, outputStream)
+          val newInputStream = System.in
+          val newOutputStream = buildOutputStream(outputStream, System.out)
+          val newErrorStream = buildOutputStream(outputStream, System.err)
+
+          // Update our global streams to be used by future output
+          // NOTE: This is not async-safe! This is expected to be broken when
+          //       running asynchronously! Use an alternative for data
+          //       communication!
+          StreamState.setStreams(newInputStream, newOutputStream, newErrorStream)
+
+          val (success, result) = {
             // Add our parent message with StreamInfo type included
-//            interpreter.doQuietly {
-//              interpreter.bind(
-//                "$streamInfo",
-//                "org.apache.toree.kernel.api.StreamInfo",
-//                new KernelMessage(
-//                  ids = parentMessage.ids,
-//                  signature = parentMessage.signature,
-//                  header = parentMessage.header,
-//                  parentHeader = parentMessage.parentHeader,
-//                  metadata = parentMessage.metadata,
-//                  contentString = parentMessage.contentString
-//                ) with StreamInfo,
-//                List( """@transient""", """implicit""")
-//              )
-              // TODO: Think of a cleaner wrapper to handle updating the Console
-              //       input and output streams
-//              interpreter.interpret(
-//                """val $updateOutput = {
-//                Console.setIn(System.in)
-//                Console.setOut(System.out)
-//                Console.setErr(System.err)
-//              }""".trim)
-//            }
+            //            interpreter.doQuietly {
+            //              interpreter.bind(
+            //                "$streamInfo",
+            //                "org.apache.toree.kernel.api.StreamInfo",
+            //                new KernelMessage(
+            //                  ids = parentMessage.ids,
+            //                  signature = parentMessage.signature,
+            //                  header = parentMessage.header,
+            //                  parentHeader = parentMessage.parentHeader,
+            //                  metadata = parentMessage.metadata,
+            //                  contentString = parentMessage.contentString
+            //                ) with StreamInfo,
+            //                List( """@transient""", """implicit""")
+            //              )
+            // TODO: Think of a cleaner wrapper to handle updating the Console
+            //       input and output streams
+            //              interpreter.interpret(
+            //                """val $updateOutput = {
+            //                Console.setIn(System.in)
+            //                Console.setOut(System.out)
+            //                Console.setErr(System.err)
+            //              }""".trim)
+            //            }
             interpreter.interpret(executeRequest.code.trim, outputStreamResult = Some(outputStream))
           }
 
-        logger.debug(s"Interpreter execution result was ${success}")
-        success match {
-          case Results.Success =>
-            val output = result.left.get
-            sender ! Left(output)
-          case Results.Error =>
-            val error = result.right.get
-            sender ! Right(error)
-          case Results.Aborted =>
-            sender ! Right(new ExecuteAborted)
-          case Results.Incomplete =>
-            // If we get an incomplete it's most likely a syntax error, so
-            // let the user know.
-            sender ! Right(new ExecuteError("Syntax Error.", "", List()))
-        }
-      } else {
-        // If we get empty code from a cell then just return ExecuteReplyOk
-        sender ! Left("")
+          // update the last execution time
+          interpreterRunning = false
+          lastExecuteRequest = System.currentTimeMillis
+
+          logger.debug(s"Interpreter execution result was ${success}")
+          success match {
+            case Results.Success =>
+              val output = result.left.get
+              sender ! Left(output)
+            case Results.Error =>
+              val error = result.right.get
+              sender ! Right(error)
+            case Results.Aborted =>
+              sender ! Right(new ExecuteAborted)
+            case Results.Incomplete =>
+              // If we get an incomplete it's most likely a syntax error, so
+              // let the user know.
+              sender ! Right(new ExecuteError("Syntax Error.", "", List()))
+          }
       }
+
     case unknownValue =>
       logger.warn(s"Received unknown message type ${unknownValue}")
       sender ! "Unknown message" // TODO: Provide a failure message type to be passed around?

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/InterpreterTaskFactory.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/InterpreterTaskFactory.scala
@@ -17,17 +17,18 @@
 
 package org.apache.toree.kernel.protocol.v5.interpreter.tasks
 
-import akka.actor.{ActorRefFactory, ActorRef}
+import akka.actor.{ActorRef, ActorRefFactory}
 import org.apache.toree.interpreter.Interpreter
+import org.apache.toree.kernel.api.KernelLike
 
-class InterpreterTaskFactory(interpreter: Interpreter) {
+class InterpreterTaskFactory(kernel: KernelLike, interpreter: Interpreter) {
   /**
    * Creates a new actor representing this specific task.
    * @param actorRefFactory The factory used to task actor will belong
    * @return The ActorRef created for the task
    */
   def ExecuteRequestTask(actorRefFactory: ActorRefFactory, name: String): ActorRef =
-    actorRefFactory.actorOf(ExecuteRequestTaskActor.props(interpreter), name)
+    actorRefFactory.actorOf(ExecuteRequestTaskActor.props(kernel, interpreter), name)
 
   /**
    *

--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/relay/ExecuteRequestRelay.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/relay/ExecuteRequestRelay.scala
@@ -22,6 +22,7 @@ import akka.actor.Actor
 import akka.pattern._
 import akka.util.Timeout
 import org.apache.toree.interpreter.{ExecuteAborted, ExecuteError, ExecuteFailure, ExecuteOutput}
+import org.apache.toree.interpreter.InterpreterTypes.InterpreterShutdownRequest
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
@@ -41,6 +42,7 @@ case class ExecuteRequestRelay(
 {
   import context._
   implicit val timeout = Timeout(21474835.seconds)
+  private var sendShutdown = false
 
   /**
    * Takes an ExecuteFailure and (ExecuteReply, ExecuteResult) with contents
@@ -75,9 +77,15 @@ case class ExecuteRequestRelay(
     future: Future[Either[ExecuteOutput, ExecuteFailure]]
   ): Future[(ExecuteReply, ExecuteResult)] = future.map { value =>
     if (value.isLeft) {
+      val payloads = if (sendShutdown) {
+        sendShutdown = false // sent
+        Payloads(Map("source" -> "ask_exit"))
+      } else {
+        Payloads()
+      }
       val data = value.left.get
       (
-        ExecuteReplyOk(1, Some(Payloads()), Some(UserExpressions())),
+        ExecuteReplyOk(1, Some(payloads), Some(UserExpressions())),
         ExecuteResult(1, data, Metadata())
       )
     } else {
@@ -115,5 +123,9 @@ case class ExecuteRequestRelay(
           val failure = ExecuteError("Error parsing magics!", error, Nil)
           Future { failureMatch(failure) }
       }) pipeTo oldSender
+
+    case InterpreterShutdownRequest =>
+
+      this.sendShutdown = true
   }
 }

--- a/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
+++ b/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
@@ -87,7 +87,7 @@ class InterpreterActorSpecForIntegration extends TestKit(
         val interpreterActor =
           system.actorOf(Props(
             classOf[InterpreterActor],
-            new InterpreterTaskFactory(interpreter)
+            new InterpreterTaskFactory(mock[KernelLike], interpreter)
           ))
 
         val executeRequest = ExecuteRequest(
@@ -110,7 +110,7 @@ class InterpreterActorSpecForIntegration extends TestKit(
         val interpreterActor =
           system.actorOf(Props(
             classOf[InterpreterActor],
-            new InterpreterTaskFactory(interpreter)
+            new InterpreterTaskFactory(mock[KernelLike], interpreter)
           ))
 
         val executeRequest = ExecuteRequest(

--- a/kernel/src/test/scala/org/apache/toree/kernel/api/KernelSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/api/KernelSpec.scala
@@ -77,7 +77,7 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
 
     kernel = new Kernel(
       mockConfig, mockActorLoader, mockInterpreterManager, mockCommManager,
-      mockPluginManager
+      mockPluginManager, ()
     )
 
     spyKernel = spy(kernel)

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActorSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActorSpec.scala
@@ -18,14 +18,14 @@
 package org.apache.toree.kernel.protocol.v5.interpreter.tasks
 
 import java.io.OutputStream
-
 import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit}
 import com.typesafe.config.ConfigFactory
 import org.apache.toree.interpreter._
+import org.apache.toree.kernel.api.KernelLike
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
-import org.mockito.Matchers.{anyBoolean, anyString, anyObject}
+import org.mockito.Matchers.{anyBoolean, anyObject, anyString}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
 import org.scalatest.{FunSpecLike, Matchers}
@@ -56,6 +56,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
         val executeRequestTask =
           system.actorOf(Props(
             classOf[ExecuteRequestTaskActor],
+            mock[KernelLike],
             mockInterpreter
           ))
 
@@ -82,6 +83,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
         val executeRequestTask =
           system.actorOf(Props(
             classOf[ExecuteRequestTaskActor],
+            mock[KernelLike],
             mockInterpreter
           ))
 
@@ -108,6 +110,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
         val executeRequestTask =
           system.actorOf(Props(
             classOf[ExecuteRequestTaskActor],
+            mock[KernelLike],
             mockInterpreter
           ))
 
@@ -134,6 +137,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
         val executeRequestTask =
           system.actorOf(Props(
             classOf[ExecuteRequestTaskActor],
+            mock[KernelLike],
             mockInterpreter
           ))
 
@@ -160,6 +164,7 @@ class ExecuteRequestTaskActorSpec extends TestKit(
         val executeRequestTask =
           system.actorOf(Props(
             classOf[ExecuteRequestTaskActor],
+            mock[KernelLike],
             mockInterpreter
           ))
 

--- a/resources/compile/application.conf
+++ b/resources/compile/application.conf
@@ -26,3 +26,4 @@ control_port  = ${?PORT1}
 hb_port       = ${?PORT2}
 shell_port    = ${?PORT3}
 iopub_port    = ${?PORT4}
+idle_timeout  = 86400s


### PR DESCRIPTION
This adds support for "exit", "quit", and ":q" to exit Toree. It also adds a session idle timeout that defaults to 24h and a command-line option to control it.