### PR TITLE
TOREE-420 Exclude org.scala-lang.modules from AddDeps

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -81,7 +81,7 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     // Grab exclusions using base dependencies (always exclude scala lang)
     val exclusions: Set[(String, String)] = (if (excludeBaseDependencies) {
       getBaseDependencies.map(_.module).map(m => (m.organization, m.name))
-    } else Nil).toSet ++ Set(("org.scala-lang", "*"))
+    } else Nil).toSet ++ Set(("org.scala-lang", "*"), ("org.scala-lang.modules", "*"))
 
     // Mark dependency that we want to download
     val start = Resolution(Set(

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
@@ -124,6 +124,14 @@ class IvyDependencyDownloader(
       scalaCompilerArtifactId, new RegexpPatternMatcher(), null
     )
 
+    val scalaLangModuleId = new ModuleId("org.scala-lang.modules", "*")
+    val scalaLangArtifactId = new ArtifactId(
+      scalaLangModuleId, "*", "*", "*"
+    )
+    val scalaLangExclusion = new DefaultExcludeRule(
+      scalaLangArtifactId, new RegexpPatternMatcher(), null
+    )
+
     // Create our dependency descriptor
     val dependencyDescriptor = new DefaultDependencyDescriptor(
       md, ModuleRevisionId.newInstance(groupId, artifactId, version),
@@ -136,6 +144,7 @@ class IvyDependencyDownloader(
     md.addExcludeRule(sourcesExclusion)
     md.addExcludeRule(javadocExclusion)
     md.addExcludeRule(scalaCompilerExclusion)
+    md.addExcludeRule(scalaLangExclusion)
 
     // Exclude our base dependencies if marked to do so
     if (excludeBaseDependencies) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/TOREE-420

Include `org.scala-lang.modules` as part of the always exclude list when using the `%AddDeps` magic.

This prevents the `scala.reflect.internal.FatalError` that crashes the kernel, when a new scala-lang module is included and reloaded.