### PR TITLE
[TOREE-422] Enable Jupyter 5.1.0 dependencies

### DIFF
--- a/etc/pip_install/setup.py
+++ b/etc/pip_install/setup.py
@@ -51,8 +51,8 @@ setup_args = dict(
     packages=['toree'],
     include_package_data=True,
     install_requires=[
-        'jupyter_core>=4.0, <5.0',
-        'jupyter_client>=4.0, <5.0',
+        'jupyter_core>=4.0',
+        'jupyter_client>=4.0',
         'traitlets>=4.0, <5.0'
     ],
     data_files=[],


### PR DESCRIPTION
Enable Jupyter 5.1.0 dependencies to avoid issues with
downgrading Jupyter Client to 4.x in distributions such as
anaconda.