### PR TITLE
[TOREE-425] Force sparkContext initialization in cluster mode

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/utils/SparkUtils.scala
+++ b/kernel/src/main/scala/org/apache/toree/utils/SparkUtils.scala
@@ -1,0 +1,32 @@
+/*
+ *  Licensed to the Apache Software Foundation (ASF) under one or more
+ *  contributor license agreements.  See the NOTICE file distributed with
+ *  this work for additional information regarding copyright ownership.
+ *  The ASF licenses this file to You under the Apache License, Version 2.0
+ *  (the "License"); you may not use this file except in compliance with
+ *  the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License
+ */
+package org.apache.toree.utils
+
+import org.apache.spark.SparkConf
+
+object SparkUtils {
+  def isSparkClusterMode(sparkConf: SparkConf): Boolean = {
+    if (sparkConf.contains("spark.submit.deployMode")) {
+      if (sparkConf.get("spark.submit.deployMode").equalsIgnoreCase("cluster")) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}
+


### PR DESCRIPTION
Kernels running in yarn-cluster mode (when launched via spark-submit)
must initialize a SparkContext in order for the Spark Yarn code
to register the application as RUNNING