### PR TITLE
Fix for TOREE-430

### DIFF
--- a/scala-interpreter/src/main/scala-2.10/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.10/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -61,6 +61,7 @@ trait ScalaInterpreterSpecific { this: ScalaInterpreter =>
   ): SparkIMain = {
     val s = new SparkIMain(settings, out)
     s.initializeSynchronous()
+    System.setProperty("spark.repl.class.outputDir", s.getClassOutputDirectory.getAbsolutePath)
     s
   }
 
@@ -288,6 +289,10 @@ trait ScalaInterpreterSpecific { this: ScalaInterpreter =>
     else variable
   }
 
+  protected def initializeIMain() = {
+    sparkIMain = newSparkIMain(settings, new JPrintWriter(lastResultOut, true))
+  }
+
   /**
    * Starts the interpreter, initializing any internal state.
    * You must call init before running this function.
@@ -295,15 +300,12 @@ trait ScalaInterpreterSpecific { this: ScalaInterpreter =>
    * @return A reference to the interpreter
    */
   override def start(): Interpreter = {
-    require(sparkIMain == null && taskManager == null)
+    require(taskManager == null)
 
     taskManager = newTaskManager()
 
     logger.debug("Initializing task manager")
     taskManager.start()
-
-    sparkIMain =
-      newSparkIMain(settings, new JPrintWriter(lastResultOut, true))
 
 
     //logger.debug("Initializing interpreter")

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -254,19 +254,21 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
     }
   }
 
+  protected def initializeIMain() = {
+    iMain = newIMain(settings, new JPrintWriter(lastResultOut, true))
+  }
+
   /**
    * Starts the interpreter, initializing any internal state.
    * @return A reference to the interpreter
    */
   override def start(): Interpreter = {
-    require(iMain == null && taskManager == null)
+    require(taskManager == null)
 
     taskManager = newTaskManager()
 
     logger.debug("Initializing task manager")
     taskManager.start()
-
-    iMain = newIMain(settings, new JPrintWriter(lastResultOut, true))
 
     //logger.debug("Initializing interpreter")
     //iMain.initializeSynchronous()

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -69,6 +69,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
   protected var settings: Settings = newSettings(List())
   settings = appendClassPath(settings)
 
+  initializeIMain()
 
   private val maxInterpreterThreads: Int = {
      if(config.hasPath("max_interpreter_threads"))


### PR DESCRIPTION
To fix TOREE-430, REPL-generated classes must be made visible to a classloader.

The only working way I found is to set the `spark.repl.class.outputDir` system property (and subsequently the corresponding Spark configuration property) to a path to an output directory of a REPL compiler. To achieve that, I had to move `SparkIMain` initialisation before creation of `SparkContext`.