### PR TITLE
Updating SBT, SBT plugins, and dependencies

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -25,6 +25,7 @@ import coursier.core.Authentication
 import coursier.Cache.Logger
 import coursier.Dependency
 import coursier.core.Repository
+import coursier.core.Resolution.ModuleVersion
 import coursier.ivy.{IvyRepository, IvyXml}
 import coursier.maven.MavenRepository
 import org.springframework.core.io.support.PathMatchingResourcePatternResolver
@@ -116,9 +117,9 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     val resolution = start.process.run(fetch).unsafePerformSync
 
     // Report any resolution errors
-    val errors: Seq[(Dependency, Seq[String])] = resolution.errors
+    val errors: Seq[(ModuleVersion, Seq[String])] = resolution.metadataErrors
     errors.foreach { case (d, e) =>
-      printStream.println(s"-> Failed to resolve ${d.module.toString()}:${d.version}")
+      printStream.println(s"-> Failed to resolve ${d._1.toString()}:${d._2}")
       e.foreach(s => printStream.println(s"    -> $s"))
     }
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,10 +32,11 @@ object Dependencies {
 
   val config = "com.typesafe" % "config" % "1.3.0" // Apache v2
 
-  val coursier = "io.get-coursier" %% "coursier" % "1.0.0-M15-1" // Apache v2
-  val coursierCache = "io.get-coursier" %% "coursier-cache" % "1.0.0-M15-1" // Apache v2
+  val coursierVersion = "1.0.0-RC10"
+  val coursier = "io.get-coursier" %% "coursier" % coursierVersion // Apache v2
+  val coursierCache = "io.get-coursier" %% "coursier-cache" % coursierVersion // Apache v2
 
-  val ivy = "org.apache.ivy" % "ivy" % "2.4.0-rc1" // Apache v2
+  val ivy = "org.apache.ivy" % "ivy" % "2.4.0" // Apache v2
 
   // use the same jackson version in test than the one provided at runtime by Spark 2.0.0
   val jacksonDatabind = "com.fasterxml.jackson.core" % "jackson-databind" % "2.6.5" // Apache v2

--- a/project/build.properties
+++ b/project/build.properties
@@ -15,4 +15,4 @@
 #  limitations under the License
 #
 
-sbt.version=0.13.13
+sbt.version=0.13.16

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -18,13 +18,13 @@
 logLevel := Level.Warn
 
 // Provides the ability to generate unifed documentation for multiple projects
-addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.0")
+addSbtPlugin("com.eed3si9n" % "sbt-unidoc" % "0.4.1")
 
 // Provides abilit to create an uber-jar
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
 
 // Provides a generated build info object to sync between build and application
-addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.6.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
 
 //  Used for signing jars published via `sbt publish-signed`
 addSbtPlugin("com.jsuereth" % "sbt-pgp" % "1.0.0")


### PR DESCRIPTION
SBT: 0.13.13 => 0.13.16

### SBT plugins
sbt-unidoc: 0.4.0 => 0.4.1
sbt-buildinfo: 0.6.1 => 0.7.0

### Dependencies
coursier and coursier-cache: 1.0.0-M15-1 => 1.0.0-RC10
ivy: 2.4.0-rc1 => 2.4.0