### PR TITLE
[TOREE-431] Explicit add Guava dependency to kernel module

### DIFF
--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -16,9 +16,9 @@
  */
 fork in Test := true
 libraryDependencies ++= Dependencies.sparkAll.value
+libraryDependencies += Dependencies.guava
 
 //
 // TEST DEPENDENCIES
 //
 libraryDependencies += Dependencies.akkaTestkit % "test"
-

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -66,6 +66,8 @@ object Dependencies {
 
   val springCore = "org.springframework" % "spring-core" % "4.1.1.RELEASE"// Apache v2
 
+  val guava = "com.google.guava" % "guava" % "14.0.1" // Apache v2
+
   // Projects
 
   val sparkAll = Def.setting{


### PR DESCRIPTION
Fix the Toree build when depending on Spark 2.2.0 by forcing the guava dependency to kernel module.