### PR TITLE
Check if file is null before delete on FileUtils

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/utils/FileUtils.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/utils/FileUtils.scala
@@ -27,11 +27,13 @@ object FileUtils {
 
   private def deleteDirRecur(file: File): Unit = {
     // delete directory recursively
-    if(file.isDirectory){
-      file.listFiles.foreach(deleteDirRecur)
-    }
-    if(file.exists){
-      file.delete
+    if (file != null){
+      if(file.isDirectory){
+        file.listFiles.foreach(deleteDirRecur)
+      }
+      if(file.exists){
+        file.delete
+      }
     }
   }
 


### PR DESCRIPTION
Found this bug on my local dev env. I added the FileUtils on April but didn't check the null pointer exception then.