### PR TITLE
Adds file tagging for z/os platforms

### DIFF
--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkProcess.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkProcess.scala
@@ -89,4 +89,17 @@ class PySparkProcess(
       "PYTHONPATH" -> updatedPythonPath
     )
   }
+
+  override protected def copyResourceToTmp(resource: String): String = {
+    val destination = super.copyResourceToTmp(resource)
+    if (System.getProperty("os.name").equals("z/OS")){
+        tagPySparkResource(destination)
+    }
+    destination 
+  }
+
+  private def tagPySparkResource(destPath: String): Unit = {
+      val exitCode = Seq("chtag", "-t", "-c", "ISO8859-1", destPath).!
+      if (exitCode != 0) logger.warn("PySpark resource was not tagged correctly.")
+  }
 }

--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkProcess.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkProcess.scala
@@ -24,6 +24,7 @@ import org.apache.commons.exec._
 import org.apache.commons.io.IOUtils
 import org.apache.spark.SparkContext
 import org.slf4j.LoggerFactory
+import sys.process._
 
 /**
  * Represents the Python process used to evaluate PySpark code.


### PR DESCRIPTION
On a z/OS system, when copying a python file to tmp, python is unable to execute scripts unless it is tagged with the appropriate file encoding. 