### PR TITLE
[TOREE-437] Establish alternate interrupt handler for background execution

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/boot/layer/HookInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/HookInitialization.scala
@@ -69,8 +69,7 @@ trait StandardHookInitialization extends HookInitialization {
     // TODO: Signals are not a good way to handle this since JVM only has the
     // proprietary sun API that is not necessarily available on all platforms
     Signal.handle(new Signal("INT"), new SignalHandler() {
-      private val MaxSignalTime: Long = 3000
-      // 3 seconds
+      private val MaxSignalTime: Long = 3000 // 3 seconds
       var lastSignalReceived: Long = 0
 
       def handle(sig: Signal) = {
@@ -109,8 +108,8 @@ trait StandardHookInitialization extends HookInitialization {
             }
         })
       } catch {
-        case e:Exception => logger.warn("Error occurred establishing alternate signal handler.  Value of " +
-          "TOREE_ALTERNATE_SIGINT is probably bad: " + altSigint + ".  Error: " + e.getMessage )
+        case e:Exception => logger.warn("Error occurred establishing alternate signal handler " +
+          "(TOREE_ALTERNATE_SIGINT = " + altSigint + ").  Error: " + e.getMessage )
       }
     }
   }

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/HookInitialization.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/HookInitialization.scala
@@ -69,8 +69,9 @@ trait StandardHookInitialization extends HookInitialization {
     // TODO: Signals are not a good way to handle this since JVM only has the
     // proprietary sun API that is not necessarily available on all platforms
     Signal.handle(new Signal("INT"), new SignalHandler() {
-      private val MaxSignalTime: Long = 3000 // 3 seconds
-      var lastSignalReceived: Long    = 0
+      private val MaxSignalTime: Long = 3000
+      // 3 seconds
+      var lastSignalReceived: Long = 0
 
       def handle(sig: Signal) = {
         val currentTime = System.currentTimeMillis()
@@ -89,6 +90,29 @@ trait StandardHookInitialization extends HookInitialization {
         }
       }
     })
+    // Define handler for alternate signal that will be fired in cases where
+    // the caller is in a background process in order to interrupt
+    // cell operations - since SIGINT doesn't propagate in those cases.
+    // Like INT above except we don't need to deal with shutdown in
+    // repeated situations.
+    val altSigint = System.getenv("TOREE_ALTERNATE_SIGINT")
+    if (altSigint != null) {
+      try {
+        Signal.handle(new Signal(altSigint), new SignalHandler() {
+
+            def handle(sig: Signal) = {
+              logger.info("Resetting code execution due to interrupt!")
+              interpreter.interrupt()
+
+              // TODO: Cancel group representing current code execution
+              //sparkContext.cancelJobGroup()
+            }
+        })
+      } catch {
+        case e:Exception => logger.warn("Error occurred establishing alternate signal handler.  Value of " +
+          "TOREE_ALTERNATE_SIGINT is probably bad: " + altSigint + ".  Error: " + e.getMessage )
+      }
+    }
   }
 
   private def registerShutdownHook(): Unit = {


### PR DESCRIPTION
Cell interrupts do not take place if Toree is running in the background (typically due to its parent being in the background).  This PR adds support for the caller of Toree to specify an alternate interrupt signal via the environment variable `TOREE_ALTERNATE_SIGINT` - the value of which should be the string indicating the alternate signal name's suffix portion (e.g., "USR2" for `SIGUSR2`).
The common scenario would be to specify this env value in the kernel.json's `env:` stanza when necessary ...
```json
  "display_name": "Apache Toree - Scala",
  "env": {
    "DEFAULT_INTERPRETER": "Scala",
    "PYTHON_EXEC": "python",
    "__TOREE_SPARK_OPTS__": "",
    "__TOREE_OPTS__": "",
    "TOREE_ALTERNATE_SIGINT": "USR2",
```

If the value of `TOREE_ALTERNATE_SIGINT` is not recognized as a valid signal name, a warning message will be logged, but the kernel's launch will proceed:
```
17/09/11 08:44:37 [WARN] o.a.t.Main$$anon$1 - Error occurred establishing alternate signal handler.  Value of TOREE_ALTERNATE_SIGINT is probably bad: FOO.  Error: Unknown signal: FOO
```

Fixes TOREE-437