### PR TITLE
fix kernel generation for Spark Yarn // TOREE-97

### DIFF
--- a/etc/pip_install/toree/toreeapp.py
+++ b/etc/pip_install/toree/toreeapp.py
@@ -35,6 +35,8 @@ INTERPRETER_LANGUAGES = {
 
 PYTHON_PATH = 'PYTHONPATH'
 SPARK_HOME ='SPARK_HOME'
+HADOOP_CONF_DIR = 'HADOOP_CONF_DIR'
+SPARK_CONF_DIR = 'SPARK_CONF_DIR'
 TOREE_SPARK_OPTS = '__TOREE_SPARK_OPTS__'
 TOREE_OPTS = '__TOREE_OPTS__'
 DEFAULT_INTERPRETER = 'DEFAULT_INTERPRETER'
@@ -56,6 +58,12 @@ class ToreeInstall(InstallKernelSpec):
 
     spark_home = Unicode(os.getenv(SPARK_HOME, '/usr/local/spark'), config=True,
         help='''Specify where the spark files can be found.'''
+    )
+    hadoop_conf_dir = Unicode(os.getenv(HADOOP_CONF_DIR, '/usr/local/hadoop'), config=True,
+        help='''Specify where the hadoop config files can be found.'''
+    )
+    spark_conf_dir = Unicode(os.getenv(SPARK_CONF_DIR, '/usr/local/spark'), config=True,
+        help='''Specify where the spark config files can be found.'''
     )
     kernel_name = Unicode('Apache Toree', config=True,
         help='Install the kernel spec with this name. This is also used as the base of the display name in jupyter.'
@@ -105,6 +113,8 @@ class ToreeInstall(InstallKernelSpec):
             TOREE_SPARK_OPTS : self.spark_opts,
             TOREE_OPTS : self.toree_opts,
             SPARK_HOME : self.spark_home,
+            HADOOP_CONF_DIR : self.hadoop_conf_dir,
+            SPARK_CONF_DIR : self.spark_conf_dir,
             PYTHON_PATH : '{0}/python:{0}/python/lib/{1}'.format(self.spark_home, py4j_zip),
             PYTHON_EXEC : self.python_exec
         }


### PR DESCRIPTION
It looks like the TOREE-97 issue -- support for Spark Yarn was closed without definitive solution (or something went wrong on the way). Toree does support it, but it won't work if a user don't add manually in their kernel.json definition, the env vars for `HADOOP_CONF_DIR`. Without that env var, Spark doesn't know what to do with the option `--master=yarn` (set in `__TOREE_SPARK_OPTS__`). It would be desirable to have it by default, and this patch provides this functionality. 

Probably this is not the nicest way to solve the problem, because it  just hard codes more vars into the JSON file -- ideally it would be nice to have an interface to add or remove env vars from those files, however, `HADOOP_CONF_DIR`  and `SPARK_CONF_DIR`  look basic to be exported. Even for an Spark Standalone deployment, `HADOOP_CONF_DIR` won't hurt.  So, here it goes our 2 cents to improve a bit the situation.

I cloned the TOREE-97 into TOREE-438 to sign this issue. 



