### PR TITLE
add Python3 support

### DIFF
--- a/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
+++ b/pyspark-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/pyspark/PySparkInterpreter.scala
@@ -165,7 +165,7 @@ class PySparkInterpreter(
       "import sys; print('{s.major}.{s.minor}.{s.micro}'.format(s=sys.version_info))").!!
 
     LanguageInfo(
-      "python",
+      pythonExecutable,
       version = version,
       fileExtension = Some(".py"),
       pygmentsLexer = Some("python"),


### PR DESCRIPTION
This supports both Python2 and Python3 now. Just remember to export PYTHON_EXEC=python3 for example. You are welcome..