### PR TITLE
Scala version specifics separation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -45,9 +45,17 @@ scalacOptions in ThisBuild ++= Seq(
   "-feature",
   "-Xfatal-warnings",
   "-language:reflectiveCalls",
-  "-target:jvm-1.6",
-  "-Xlint" // Scala 2.11.x only
+  "-target:jvm-1.6"
 )
+
+scalacOptions in ThisBuild ++= {
+  if ((scalaVersion in ThisBuild).value.startsWith("2.11")) {
+    Seq("-Xlint")
+  } else {
+    Nil
+  }
+}
+
 // Java-based options for compilation (all tasks)
 // NOTE: Providing a blank flag causes failures, only uncomment with options
 //javacOptions in Compile ++= Seq(""),

--- a/client/build.sbt
+++ b/client/build.sbt
@@ -19,7 +19,7 @@ scalacOptions += "-language:reflectiveCalls"
 
 // Main library dependencies to function
 libraryDependencies ++= Seq(
-  Dependencies.akkaActor,
-  Dependencies.akkaSlf4j,
-  Dependencies.akkaTestkit % "test"
+  Dependencies.akkaActor.value,
+  Dependencies.akkaSlf4j.value,
+  Dependencies.akkaTestkit.value % "test"
 )

--- a/communication/build.sbt
+++ b/communication/build.sbt
@@ -17,7 +17,7 @@
 
 libraryDependencies ++= Seq(
   Dependencies.jeroMq,
-  Dependencies.akkaActor,
-  Dependencies.akkaSlf4j,
-  Dependencies.akkaTestkit % "test"
+  Dependencies.akkaActor.value,
+  Dependencies.akkaSlf4j.value,
+  Dependencies.akkaTestkit.value % "test"
 )

--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -21,4 +21,4 @@ libraryDependencies += Dependencies.guava
 //
 // TEST DEPENDENCIES
 //
-libraryDependencies += Dependencies.akkaTestkit % "test"
+libraryDependencies += Dependencies.akkaTestkit.value % "test"

--- a/kernel/src/main/scala-2.10/org/apache/toree/boot/KernelBootstrapSpecific.scala
+++ b/kernel/src/main/scala-2.10/org/apache/toree/boot/KernelBootstrapSpecific.scala
@@ -1,0 +1,13 @@
+package org.apache.toree.boot
+
+/**
+  * Provides Scala version-specific features needed for the [[KernelBootstrap]] class.
+  */
+private[boot] trait KernelBootstrapSpecific {
+  /**
+    * Initializes all kernel systems.
+    */
+  def initialize() = {
+    this
+  }
+}

--- a/kernel/src/main/scala-2.11/org/apache/toree/boot/KernelBootstrapSpecific.scala
+++ b/kernel/src/main/scala-2.11/org/apache/toree/boot/KernelBootstrapSpecific.scala
@@ -1,0 +1,19 @@
+package org.apache.toree.boot
+
+import org.apache.spark.repl.Main
+
+/**
+  * Provides Scala version-specific features needed for the [[KernelBootstrap]] class.
+  */
+private[boot] trait KernelBootstrapSpecific {
+  protected val outputDir = Main.outputDir
+
+  /**
+    * Initializes all kernel systems.
+    */
+  def initialize() = {
+    System.setProperty("spark.repl.class.outputDir", outputDir.getAbsolutePath)
+
+    this
+  }
+}

--- a/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
@@ -27,16 +27,12 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.security.KernelSecurityManager
 import org.apache.toree.utils.LogLike
-
-import org.apache.spark.repl.Main
-
 import org.zeromq.ZMQ
-
 import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.util.Try
 
-class KernelBootstrap(config: Config) extends LogLike {
+class KernelBootstrap(config: Config) extends LogLike with KernelBootstrapSpecific {
   this: BareInitialization with ComponentInitialization
     with HandlerInitialization with HookInitialization =>
 
@@ -49,13 +45,11 @@ class KernelBootstrap(config: Config) extends LogLike {
   private var kernel: Kernel                    = _
 
   private var interpreters: Seq[Interpreter]    = Nil
-  private val rootDir                           = Main.rootDir
-  private val outputDir                         = Main.outputDir
 
   /**
    * Initializes all kernel systems.
    */
-  def initialize() = {
+  override def initialize() = {
     // TODO: Investigate potential to initialize System out/err/in to capture
     //       Console DynamicVariable initialization (since takes System fields)
     //       and redirect it to a workable location (like an actor) with the
@@ -67,7 +61,7 @@ class KernelBootstrap(config: Config) extends LogLike {
 
     // ENSURE THAT WE SET THE RIGHT SPARK PROPERTIES
     val execUri = System.getenv("SPARK_EXECUTOR_URI")
-    System.setProperty("spark.repl.class.outputDir", outputDir.getAbsolutePath)
+
     if (execUri != null) {
       System.setProperty("spark.executor.uri", execUri)
     }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -22,9 +22,17 @@ object Dependencies {
 
   // Libraries
 
-  val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.4.20" // Apache v2
-  val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % "2.4.20" // Apache v2
-  val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % "2.4.20" // Apache v2
+  val akkaVersion = Def.setting {
+    scalaVersion.value match {
+      case version if version.startsWith("2.11") => "2.4.20"
+      case version if version.startsWith("2.10") => "2.3.16"
+      case version @ _ => throw new RuntimeException("Unable to choose Akka version for Scala " + version)
+    }
+  }
+
+  val akkaActor = Def.setting { "com.typesafe.akka" %% "akka-actor" % akkaVersion.value } // Apache v2
+  val akkaSlf4j = Def.setting { "com.typesafe.akka" %% "akka-slf4j" % akkaVersion.value } // Apache v2
+  val akkaTestkit = Def.setting { "com.typesafe.akka" %% "akka-testkit" % akkaVersion.value } // Apache v2
 
   val clapper = "org.clapper" %% "classutil" % "1.0.12" // BSD 3-clause license, used for detecting plugins
 

--- a/scala-interpreter/src/main/scala-2.10/org/apache/toree/kernel/interpreter/scala/ScalaDisplayersSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.10/org/apache/toree/kernel/interpreter/scala/ScalaDisplayersSpecific.scala
@@ -1,0 +1,19 @@
+package org.apache.toree.kernel.interpreter.scala
+
+import scala.reflect.runtime.universe
+
+/**
+  * Provides Scala version-specific features needed for the [[ScalaDisplayers]].
+  */
+private[scala] object ScalaDisplayersSpecific {
+  /**
+    * Returns a term name for the specified name.
+    *
+    * @param name the name
+    *
+    * @return the term name
+    */
+  private[scala] def getTermName(name: String) = {
+    universe.newTermName(name)
+  }
+}

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaDisplayersSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaDisplayersSpecific.scala
@@ -1,0 +1,19 @@
+package org.apache.toree.kernel.interpreter.scala
+
+import scala.reflect.runtime.universe
+
+/**
+  * Provides Scala version-specific features needed for the [[ScalaDisplayers]].
+  */
+private[scala] object ScalaDisplayersSpecific {
+  /**
+    * Returns a term name for the specified name.
+    *
+    * @param name the name
+    *
+    * @return the term name
+    */
+  private[scala] def getTermName(name: String) = {
+    universe.TermName(name)
+  }
+}

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaDisplayers.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaDisplayers.scala
@@ -18,18 +18,15 @@
 package org.apache.toree.kernel.interpreter.scala
 
 import java.util
-
-import scala.collection.JavaConverters._
-import scala.collection.mutable
-import scala.util.Try
+import jupyter.{Displayer, Displayers, MIMETypes}
 import org.apache.spark.SparkContext
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
-import jupyter.Displayer
-import jupyter.Displayers
-import jupyter.MIMETypes
 import org.apache.toree.kernel.protocol.v5.MIMEType
 import org.apache.toree.magic.MagicOutput
+import scala.collection.JavaConverters._
+import scala.collection.mutable
+import scala.util.Try
 
 object ScalaDisplayers {
 
@@ -120,7 +117,7 @@ object ScalaDisplayers {
 
     private def callToHTML(obj: Any): Option[String] = {
       import scala.reflect.runtime.{universe => ru}
-      val toHtmlMethodName = ru.TermName("toHtml")
+      val toHtmlMethodName = ScalaDisplayersSpecific.getTermName("toHtml")
       val classMirror = ru.runtimeMirror(obj.getClass.getClassLoader)
       val objMirror = classMirror.reflect(obj)
       val toHtmlSym = objMirror.symbol.toType.member(toHtmlMethodName)


### PR DESCRIPTION
This PR separates code, dependencies, etc. specific to 2.10 and 2.11 Scala versions.