### PR TITLE
Add support for showing nulls and arrays by dataframe magic

### DIFF
--- a/kernel/src/test/scala/org/apache/toree/utils/DataFrameConverterSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/utils/DataFrameConverterSpec.scala
@@ -17,30 +17,34 @@
 
 package org.apache.toree.utils
 
-import org.apache.spark.rdd.RDD
-import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.StructType
-import org.mockito.Matchers._
+import org.apache.spark.sql.{DataFrame, Row}
 import org.mockito.Mockito._
 import org.scalatest.mock.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
 import play.api.libs.json.{JsArray, JsString, Json}
+import test.utils.SparkContextProvider
 
-class DataFrameConverterSpec extends FunSpec with MockitoSugar with Matchers {
+import scala.collection.mutable
+
+class DataFrameConverterSpec extends FunSpec with MockitoSugar with Matchers with BeforeAndAfterAll {
+
+  lazy val spark = SparkContextProvider.sparkContext
+
+  override protected def afterAll(): Unit = {
+    spark.stop()
+    super.afterAll()
+  }
+
   val dataFrameConverter: DataFrameConverter = new DataFrameConverter
   val mockDataFrame = mock[DataFrame]
-  val mockRdd = mock[RDD[Any]]
+  val mockRdd = spark.parallelize(Seq(Row(new mutable.WrappedArray.ofRef(Array("test1", "test2")), 2, null)))
   val mockStruct = mock[StructType]
   val columns = Seq("foo", "bar").toArray
-  val rowsOfArrays = Array( Array("a", "b"), Array("c", "d") )
-  val rowsOfStrings = Array("test1","test2")
-  val rowsOfString = Array("test1")
 
   doReturn(mockStruct).when(mockDataFrame).schema
   doReturn(columns).when(mockStruct).fieldNames
   doReturn(mockRdd).when(mockDataFrame).rdd
-  doReturn(mockRdd).when(mockRdd).map(any())(any())
-  doReturn(rowsOfArrays).when(mockRdd).take(anyInt())
 
   describe("DataFrameConverter") {
     describe("#convert") {
@@ -49,24 +53,24 @@ class DataFrameConverterSpec extends FunSpec with MockitoSugar with Matchers {
         val jsValue = Json.parse(someJson.get)
         jsValue \ "columns" should be (JsArray(Seq(JsString("foo"), JsString("bar"))))
         jsValue \ "rows" should be (JsArray(Seq(
-          JsArray(Seq(JsString("a"), JsString("b"))),
-          JsArray(Seq(JsString("c"), JsString("d")))))
-        )
+          JsArray(Seq(JsString("[test1, test2]"), JsString("2"), JsString("null")))
+        )))
       }
       it("should convert to csv") {
-        doReturn(rowsOfStrings).when(mockRdd).take(anyInt())
         val csv = dataFrameConverter.convert(mockDataFrame, "csv").get
-        val values = csv.split("\n").map(_.split(","))
-        values(0) should contain allOf ("foo","bar")
+        val values = csv.split("\n")
+        values(0) shouldBe "foo,bar"
+        values(1) shouldBe "[test1, test2],2,null"
       }
       it("should convert to html") {
-        doReturn(rowsOfStrings).when(mockRdd).take(anyInt())
         val html = dataFrameConverter.convert(mockDataFrame, "html").get
         html.contains("<th>foo</th>") should be(true)
         html.contains("<th>bar</th>") should be(true)
+        html.contains("<td>[test1, test2]</td>") should be(true)
+        html.contains("<td>2</td>") should be(true)
+        html.contains("<td>null</td>") should be(true)
       }
       it("should convert limit the selection") {
-        doReturn(rowsOfString).when(mockRdd).take(1)
         val someLimited = dataFrameConverter.convert(mockDataFrame, "csv", 1)
         val limitedLines = someLimited.get.split("\n")
         limitedLines.length should be(2)


### PR DESCRIPTION
This change adds support for showing dataframes with arrays and nulls by %%dataframe magic. Now null values cause NullPointerException and arrays are showed as "WrappedArray(1, 2, 3)" but not "[1, 2, 3]".