### PR TITLE
Support for --alternate-sigint command-line option

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/boot/CommandLineOptions.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/CommandLineOptions.scala
@@ -105,6 +105,12 @@ class CommandLineOptions(args: Seq[String]) {
       "The default value is 100 milliseconds."
   ).withRequiredArg().ofType(classOf[Long])
 
+  private val _alternate_sigint = parser.accepts(
+    "alternate-sigint",
+    "Specifies the signal to use instead of SIGINT for interrupting a long-running cell. " +
+      "The value is a string and does not include the SIG prefix. Use of USR2 is recommended."
+  ).withRequiredArg().ofType(classOf[String])
+
   private val options = parser.parse(args.map(_.trim): _*)
 
   /*
@@ -155,6 +161,7 @@ class CommandLineOptions(args: Seq[String]) {
         .flatMap(list => if (list.isEmpty) None else Some(list)),
       "max_interpreter_threads" -> get(_max_interpreter_threads),
       "spark_context_intialization_timeout" -> get(_spark_context_intialization_timeout),
+      "alternate_sigint" -> get(_alternate_sigint),
       "jar_dir" -> get(_jar_dir),
       "default_interpreter" -> get(_default_interpreter),
       "nosparkcontext" -> (if (has(_nosparkcontext)) Some(true) else Some(false)),

--- a/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
@@ -120,6 +120,7 @@ class KernelBootstrap(config: Config) extends LogLike {
 
     // Initialize our non-shutdown hooks that handle various JVM events
     initializeHooks(
+      config = config,
       interpreter = interpreter
     )
 

--- a/kernel/src/test/scala/org/apache/toree/boot/CommandLineOptionsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/boot/CommandLineOptionsSpec.scala
@@ -355,5 +355,34 @@ class CommandLineOptionsSpec extends FunSpec with Matchers {
         }
       }
     }
+
+    describe("when dealing with --alternate-sigint") {
+      val key = "alternate_sigint"
+
+      it("when option is not specified, Config.hasPath method must return false") {
+        val options = new CommandLineOptions(Nil)
+        val config: Config = options.toConfig
+        config.hasPath(key) should be(false)
+      }
+
+      it("when option is specified, the value must be returned") {
+        val options = new CommandLineOptions(List(
+          "--alternate-sigint", "foo"
+        ))
+        val config: Config = options.toConfig
+        config.getString(key) should be("foo")
+      }
+
+      it("when a value is not specified, an exception must be thrown") {
+        intercept[OptionException] {
+          val options = new CommandLineOptions(List(
+            "--alternate-sigint"
+          ))
+          val config: Config = options.toConfig
+        }
+      }
+
+    }
+
   }
 }


### PR DESCRIPTION
Added support for --alternate-sigint command-line option and
removed the usage of TOREE_ALTERNATE_SIGINT environment variable.
Changed the signature of HookInitialization.initializeHooks() to
pass in the Config. Added unit tests for the new command-line.
option.

Addresses issue TOREE-456.