### PR TITLE
[TOREE-463] break out scala interpreter initialization to speed up startup

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/KernelBootstrap.scala
@@ -65,6 +65,8 @@ class KernelBootstrap(config: Config) extends LogLike {
     //      customPrintStream as their initial Console.out value
     //
 
+    val startNanos: Double = System.nanoTime()
+
     // ENSURE THAT WE SET THE RIGHT SPARK PROPERTIES
     val execUri = System.getenv("SPARK_EXECUTOR_URI")
     System.setProperty("spark.repl.class.outputDir", outputDir.getAbsolutePath)
@@ -77,6 +79,9 @@ class KernelBootstrap(config: Config) extends LogLike {
     // Do this first to support shutting down quickly before entire system
     // is ready
     initializeShutdownHook()
+
+    //handle scala interpreter separately because is slow to startup
+    val (interpreterManager, maybeEventualPartialScalaInterpreter) = initializeSlowComponents(config)
 
     // Initialize the bare minimum to report a starting message
     val (actorSystem, actorLoader, kernelMessageRelayActor, statusDispatch) =
@@ -96,10 +101,12 @@ class KernelBootstrap(config: Config) extends LogLike {
     // Initialize components needed elsewhere
     val (commStorage, commRegistrar, commManager, interpreter,
       kernel, dependencyDownloader,
-      magicManager, pluginManager, responseMap) =
+      magicManager, pluginManager, responseMap, maybeEventualReadyScalaInterpreter) =
       initializeComponents(
         config      = config,
-        actorLoader = actorLoader
+        actorLoader = actorLoader,
+        interpreterManager = interpreterManager,
+        maybeEventualScalaInterp = maybeEventualPartialScalaInterpreter
       )
     this.interpreters ++= Seq(interpreter)
 
@@ -126,12 +133,19 @@ class KernelBootstrap(config: Config) extends LogLike {
     logger.debug("Initializing security manager")
     System.setSecurityManager(new KernelSecurityManager)
 
+    //Wait for scala interpreter to finish initializing if it is present
+    maybeEventualReadyScalaInterpreter.map { eventualScalaInterpreter =>
+      Await.ready(eventualScalaInterpreter, Duration.Inf)
+    }
+
     logger.debug("Running postInit for interpreters")
     interpreters foreach {_.postInit()}
 
     logger.info("Marking relay as ready for receiving messages")
     kernelMessageRelayActor ! true
 
+    val endNanos: Double = System.nanoTime()
+    logger.trace(s"Kernel bootstrap took ${(endNanos - startNanos) / 1000000000}s")
     this
   }
 

--- a/kernel/src/main/scala/org/apache/toree/boot/layer/InterpreterManager.scala
+++ b/kernel/src/main/scala/org/apache/toree/boot/layer/InterpreterManager.scala
@@ -20,8 +20,9 @@ package org.apache.toree.boot.layer
 import org.apache.toree.kernel.api.KernelLike
 import com.typesafe.config.Config
 import org.apache.toree.interpreter._
-import scala.collection.JavaConverters._
+import org.apache.toree.kernel.interpreter.scala.ScalaInterpreter
 
+import scala.collection.JavaConverters._
 import org.slf4j.LoggerFactory
 
 case class InterpreterManager(
@@ -29,6 +30,10 @@ case class InterpreterManager(
   interpreters: Map[String, Interpreter] = Map[String, Interpreter]()
 ) {
 
+  //Scala Interpreter is handled separately
+  def initializeRegularInterpreters(kernel: KernelLike): Unit = interpreters
+    .filterNot { case (name, interp) => name == "Scala" && interp.isInstanceOf[ScalaInterpreter] }
+    .foreach { case (_, interpreter) => interpreter.init(kernel) }
 
   def initializeInterpreters(kernel: KernelLike): Unit = {
     interpreters.values.foreach(interpreter =>
@@ -46,7 +51,14 @@ case class InterpreterManager(
   def defaultInterpreter: Option[Interpreter] = {
     interpreters.get(default)
   }
+
+  /**
+   * returns builtin toree scala interpreter if present.
+   * @return an option containg the scala interpreter if present
+   */
+  def scalaInterpreter: Option[ScalaInterpreter] = interpreters.get("Scala").collect { case s: ScalaInterpreter => s}
 }
+
 
 object InterpreterManager {
 

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -258,14 +258,13 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
    * Starts the interpreter, initializing any internal state.
    * @return A reference to the interpreter
    */
-  override def start(): Interpreter = {
+  override def start(): ScalaInterpreter = {
     require(iMain == null && taskManager == null)
 
     taskManager = newTaskManager()
 
     logger.debug("Initializing task manager")
     taskManager.start()
-
     iMain = newIMain(settings, new JPrintWriter(lastResultOut, true))
 
     //logger.debug("Initializing interpreter")


### PR DESCRIPTION
The goal of this PR is to decrease Toree's startup time by breaking out the ScalaInterpreter initialization and running it in its own thread. If you count the startup time as the time it takes KernelBootstrap.initizalize to complete, I saw the average startup time go from 8.16s to 5.69s on my laptop. I started the kernel ten times with the original code and my changes.
