### PR TITLE
[TOREE-467] Fix ShowTypes magic functionality

### DIFF
--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommInfoRequestHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommInfoRequestHandlerSpec.scala
@@ -47,6 +47,8 @@ class CommInfoRequestHandlerSpec extends TestKit(
   )
 ) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
 
+  var WAIT_TIME = 2.seconds
+
   var mockCommStorage: CommStorage = mock[CommStorage]
 
   val actorLoader: ActorLoader =  mock[ActorLoader]
@@ -72,7 +74,7 @@ class CommInfoRequestHandlerSpec extends TestKit(
       when(mockCommStorage.getCommIdsFromTarget("test.name")).thenReturn(Option(scala.collection.immutable.IndexedSeq("1", "2")))
 
       actor ! kernelMessage
-      val reply = relayProbe.receiveOne(1.seconds).asInstanceOf[KernelMessage]
+      val reply = relayProbe.receiveOne(WAIT_TIME).asInstanceOf[KernelMessage]
       val commInfo = Json.parse(reply.contentString).as[CommInfoReply]
 
       commInfo.comms.size should equal (2)
@@ -91,7 +93,7 @@ class CommInfoRequestHandlerSpec extends TestKit(
     when(mockCommStorage.getCommIdsFromTarget("test.name2")).thenReturn(Option(scala.collection.immutable.IndexedSeq("3", "4")))
 
     actor ! kernelMessage
-    val reply = relayProbe.receiveOne(1.seconds).asInstanceOf[KernelMessage]
+    val reply = relayProbe.receiveOne(WAIT_TIME).asInstanceOf[KernelMessage]
     val commInfo = Json.parse(reply.contentString).as[CommInfoReply]
 
     commInfo.comms.size should equal (4)
@@ -110,7 +112,7 @@ class CommInfoRequestHandlerSpec extends TestKit(
     when(mockCommStorage.getCommIdsFromTarget("test.name")).thenReturn(Option(scala.collection.immutable.IndexedSeq("1", "2")))
 
     actor ! kernelMessage
-    val reply = relayProbe.receiveOne(1.seconds).asInstanceOf[KernelMessage]
+    val reply = relayProbe.receiveOne(WAIT_TIME).asInstanceOf[KernelMessage]
     val commInfo = Json.parse(reply.contentString).as[CommInfoReply]
 
     commInfo.comms.size should equal (0)

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -25,7 +25,7 @@ import org.apache.spark.SparkContext
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.repl.Main
 import org.apache.toree.interpreter._
-import org.apache.toree.kernel.api.KernelLike
+import org.apache.toree.kernel.api.{KernelLike, KernelOptions}
 import org.apache.toree.utils.TaskManager
 import org.slf4j.LoggerFactory
 import org.apache.toree.kernel.BuildInfo
@@ -221,9 +221,26 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
         }
 
         // suppress interpreter-defined values
-        if (!name.matches("res\\d+")) {
+        if ( defLine.matches("res\\d+(.*)[\\S\\s]") == false ) {
           definitions.append(defLine)
         }
+
+        // show type, except on MagicOutputs
+        if(showType && !vtype.contains("MagicOutput")) {
+          if (! lastResultAsString.contains(defLine)) {
+            // remove interpreter-defined variable names
+            if(defLine.startsWith("res")) {
+              val v = defLine.split("^res\\d+:\\s")(1)
+              lastResultAsString = v
+              lastResult = Some(v)
+            } else {
+              lastResultAsString = defLine
+              lastResult = Some(defLine)
+            }
+
+          }
+        }
+
 
       case Definition(defType, name) =>
         lastResultAsString = ""
@@ -282,7 +299,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
          val lastOutput = lastResultOut.toString("UTF-8").trim
          lastResultOut.reset()
 
-         val (obj, defStr, text) = prepareResult(lastOutput)
+         val (obj, defStr, text) = prepareResult(lastOutput, KernelOptions.showTypes, KernelOptions.noTruncation )
          defStr.foreach(kernel.display.content(MIMEType.PlainText, _))
          text.foreach(kernel.display.content(MIMEType.PlainText, _))
          val output = obj.map(Displayers.display(_).asScala.toMap).getOrElse(Map.empty)

--- a/scala-interpreter/src/test/scala-2.11/scala/ScalaInterpreterSpec.scala
+++ b/scala-interpreter/src/test/scala-2.11/scala/ScalaInterpreterSpec.scala
@@ -418,15 +418,20 @@ class ScalaInterpreterSpec extends FunSpec
       it("should truncate result of res result") {
         interpreter.start()
         doReturn(38).when(mockSparkIMain).eval("i")
+        doReturn("ABC").when(mockSparkIMain).eval("s")
         doReturn(Vector(1, 2)).when(mockSparkIMain).eval("res4")
         doReturn("snakes").when(mockSparkIMain).eval("resabc")
 
-        //  Results that match
+        //  Results that match  ==> Result, Definitions, Text
+        //  val i: Int = 38 ==> i: Int = 38
         interpreter.prepareResult("i: Int = 38") should be((Some(38), Some("i = 38\n"), None))
-        interpreter.prepareResult("i: Int = 38",true) should be((Some(38), Some("i: Int = 38\n"), None))
+        interpreter.prepareResult("i: Int = 38",true) should be((Some("i: Int = 38\n"), Some("i: Int = 38\n"), None))
+        // val s = "ABC" ==> s: String = ABC
+        interpreter.prepareResult("s: String = ABC") should be((Some("ABC"), Some("s = ABC\n"), None))
+        interpreter.prepareResult("s: String = ABC",true) should be((Some("s: String = ABC\n"), Some("s: String = ABC\n"), None))
         // resN results are suppressed
-        interpreter.prepareResult("res4: String = \nVector(1\n, 2\n)") should be((Some(Vector(1, 2)), None, None))
-        interpreter.prepareResult("res4: String = \nVector(1\n, 2\n)",true) should be((Some(Vector(1, 2)), None, None))
+        interpreter.prepareResult("res4: String = Vector(1, 2)") should be((Some(Vector(1, 2)), None, None))
+        interpreter.prepareResult("res4: String = Vector(1, 2)",true) should be((Some("String = Vector(1, 2)\n"), None, None))
         // missing variables are None, unmatched lines are returned in text
         interpreter.prepareResult("res123") should be((None, None, Some("res123\n")))
         interpreter.prepareResult("res123: Int = 38") should be((None, None, Some("res123: Int = 38\n")))

--- a/test_toree.py
+++ b/test_toree.py
@@ -49,7 +49,7 @@ class ToreeScalaKernelTests(jupyter_kernel_test.KernelTests):
         },
         # showtypes controls info displayed to stdout, return values are
         # handled by Jupyter displayers.
-        {'code': '%showtypes on\n1', 'result': '1'},
+        {'code': '%showtypes on\n1', 'result': 'Int = 1\n'},
         {'code': '%showtypes off\n1', 'result': '1'}
     ]
 


### PR DESCRIPTION
There was a regression where the actual configuration for ShowTypes
and Truncation was not wired with the code that perform the output
format, thus making those magics to stop working.