### PR TITLE
[TOREE-474] support for custom resolvers (for %AddDeps)

### DIFF
--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/CoursierDependencyDownloader.scala
@@ -252,7 +252,7 @@ class CoursierDependencyDownloader extends DependencyDownloader {
     override def downloadProgress(url: String, downloaded: Long): Unit = {
       downloadAmount.put(url, downloaded)
 
-      val ratio = downloadAmount(url).toDouble / downloadTotal(url).toDouble
+      val ratio = downloadAmount(url).toDouble / downloadTotal.getOrElse[Long](url, 1).toDouble
       val percent = ratio * 100.0
 
       if (trace) printStream.printf(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -32,7 +32,7 @@ object Dependencies {
 
   val config = "com.typesafe" % "config" % "1.3.0" // Apache v2
 
-  val coursierVersion = "1.0.0-RC10"
+  val coursierVersion = "1.0.3"
   val coursier = "io.get-coursier" %% "coursier" % coursierVersion // Apache v2
   val coursierCache = "io.get-coursier" %% "coursier-cache" % coursierVersion // Apache v2
 


### PR DESCRIPTION
The code path where `downloadTotal` is set is inconsistently reached for certain repositories, like Artifactory. This should fix the masked issue (`java.util.NoSuchElementException: key not found` in `downloadTotal`) that was derailing the directory traversal process specified in TOREE-474. The visible error in the logs was the generic `An error occurred while downloading` specified in the Logger overrides.