### PR TITLE
[TOREE-504] Add protocol version to shutdown_reply header

### DIFF
--- a/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
+++ b/kernel/src/main/scala/org/apache/toree/kernel/protocol/v5/handler/ShutdownHandler.scala
@@ -41,6 +41,8 @@ class ShutdownHandler(
   override def process(kernelMessage: KernelMessage): Future[_] = Future {
     logKernelMessageAction("Initiating Shutdown request for", kernelMessage)
 
+    val kernelInfo = SparkKernelInfo
+
     val shutdownReply = ShutdownReply(false)
 
     val replyHeader = Header(
@@ -48,7 +50,7 @@ class ShutdownHandler(
       "",
       java.util.UUID.randomUUID.toString,
       ShutdownReply.toTypeString,
-      "")
+      kernelInfo.protocolVersion)
 
     val kernelResponseMessage = KMBuilder()
       .withIds(kernelMessage.ids)


### PR DESCRIPTION
The `shutdown_reply` message header now includes the protocol version indicator.  Since it was previously only including an empty string, applications that want to adapt different versions on the fly expect a float in that entry.  This change adds that value.