### PR TITLE
[TOREE-505] Fix Oracle JDK8 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@
 # limitations under the License.
 #
 
+dist: trusty
 language: scala
 scala:
     - "2.11"
@@ -46,4 +47,3 @@ cache:
 #branches:
 #    only:
 #        - master
-


### PR DESCRIPTION
Install of Oracle JDK 8 Failing in Travis CI and as a result,
build is failing for new pull requests.

We just need to add `dist: trusty` in the .travis.yml file
as mentioned in the issue below:
https://travis-ci.community/t/install-of-oracle-jdk-8-failing/3038