### PR TITLE
[TOREE-508] Reply errors to iopub.error instead of iopub.exec_result

### DIFF
--- a/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/package.scala
+++ b/protocol/src/main/scala/org/apache/toree/kernel/protocol/v5/package.scala
@@ -35,7 +35,8 @@ package object v5 {
       if(kv.isEmpty) {
         Map.empty
       } else {
-        kv.toMap.mapValues(v => Json.parse(v))
+        // triple quotes due https://github.com/scala/bug/issues/6476
+        kv.toMap.mapValues(v => Json.parse(s""""$v""""))
       }
     }
 

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/KMBuilderSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/KMBuilderSpec.scala
@@ -68,6 +68,12 @@ class KMBuilderSpec extends FunSpec with Matchers {
         val metadata = builder.build(includeDefaultMetadata = false).metadata
         metadata should be(Metadata())
       }
+
+      it("should merge metadata with default") {
+        val builder = new KM2
+        val metadata = builder.withMetadata(Metadata("some" -> "value")).build.metadata
+        metadata should contain key("some")
+      }
     }
 
     describe("withXYZ"){

--- a/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
+++ b/scala-interpreter/src/main/scala-2.11/org/apache/toree/kernel/interpreter/scala/ScalaInterpreterSpecific.scala
@@ -426,7 +426,7 @@ trait ScalaInterpreterSpecific extends SettingsProducerLike { this: ScalaInterpr
         ExecuteError(
           ex.getClass.getName,
           ex.getLocalizedMessage,
-          formattedException.slice(1, formattedException.size - 1).toList
+          formattedException.toList
         )
       // Compile time error, need to check internal reporter
       case _ =>


### PR DESCRIPTION
Fix string values within Metadata, the values needs to be json string.
Reply errors to iopub.error instead of iopub.exec_result
