### PR TITLE
Remove traitlets version cap

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-name: Apache Toreee build
+name: Apache Toree build
 
 on:
   pull_request:

--- a/etc/pip_install/setup.py
+++ b/etc/pip_install/setup.py
@@ -53,7 +53,7 @@ setup_args = dict(
     install_requires=[
         'jupyter_core>=4.0',
         'jupyter_client>=4.0',
-        'traitlets>=4.0, <5.0'
+        'traitlets>=4.0'
     ],
     data_files=[],
     classifiers=[


### PR DESCRIPTION
Traitlets 5.x has been out for quite a while and Toree's use of traitlets (`ToreeApp` derives from class `Application`) is compatible and we shouldn't be downgrading traitlets during toree pip installs.