### PR TITLE
[TOREE-530] Ivy downloader with Spark 3.2.x

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Checkout
       uses: actions/setup-java@v2
       with:
-        distribution: 'zulu'
+        distribution: 'temurin'
         java-version: ${{ matrix.java }}
     - name: Add SBT launcher
       run: |

--- a/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
+++ b/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala
@@ -189,8 +189,9 @@ class IvyDependencyDownloader(
     val moduleDescriptor = report.getModuleDescriptor
     ivy.retrieve(
       moduleDescriptor.getModuleRevisionId,
-      baseDirectory + "/[artifact](-[classifier]).[ext]",
-      new RetrieveOptions().setConfs(Seq("default").toArray)
+      new RetrieveOptions()
+        .setConfs(Seq("default").toArray)
+        .setDestArtifactPattern(baseDirectory + "/[artifact](-[classifier]).[ext]")
     )
 
     artifactURLs.map(_.toURI)


### PR DESCRIPTION
Fixes [TOREE-530](https://issues.apache.org/jira/browse/TOREE-530)

**OBS**: Uses OpenJDK (temurin) istead of zulu, so unit tests with java 8 passes.
Also fixes https://github.com/apache/incubator-toree/pull/175

Trying to build toree with APACHE_SPARK_VERSION=3.2.1 breaks because of deprecated API.

```
[error] apache/incubator-toree/kernel-api/src/main/scala/org/apache/toree/dependencies/IvyDependencyDownloader.scala:190:9: method retrieve in class Ivy is deprecated
[error]     ivy.retrieve(
[error]         ^
[error] one error found
[error] (kernelApi / Compile / compileIncremental) Compilation failed
[error] Total time: 64 s (01:04), completed Feb 18, 2022, 1:13:46 PM
make: *** [Makefile:108: target/scala-2.12/toree-assembly-0.6.0.dev0-incubating-SNAPSHOT.jar] Error 1 
```