### PR TITLE
[TOREE-533][BUILD] Migrate sbt script to slash syntax

### DIFF
--- a/kernel/build.sbt
+++ b/kernel/build.sbt
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License
  */
-fork in Test := true
+Test / fork := true
 libraryDependencies ++= Dependencies.sparkAll.value
 libraryDependencies += Dependencies.guava
 

--- a/plugins/build.sbt
+++ b/plugins/build.sbt
@@ -15,7 +15,7 @@
  *  limitations under the License
  */
 
-fork in Test := true
+Test / fork := true
 
 // Needed for type inspection
 libraryDependencies ++= Seq(

--- a/project/CommonPlugin.scala
+++ b/project/CommonPlugin.scala
@@ -14,7 +14,7 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License
  */
-import sbt._
+import sbt.{Def, _}
 import sbt.Keys._
 
 object CommonPlugin extends AutoPlugin {
@@ -29,24 +29,24 @@ object CommonPlugin extends AutoPlugin {
   }
   import autoImport._
 
-  override def projectSettings = {
+  override def projectSettings: Seq[Def.Setting[_]] = {
     inConfig(UnitTest)(Defaults.testSettings) ++
     inConfig(IntegrationTest)(Defaults.testSettings) ++
     inConfig(SystemTest)(Defaults.testSettings) ++
     Seq(
-      testOptions in UnitTest := Seq(Tests.Filter(unitFilter)),
-      testOptions in IntegrationTest := Seq(Tests.Filter(intFilter)),
-      testOptions in SystemTest := Seq(Tests.Filter(sysFilter)),
+      UnitTest / testOptions := Seq(Tests.Filter(unitFilter)),
+      IntegrationTest / testOptions := Seq(Tests.Filter(intFilter)),
+      SystemTest / testOptions := Seq(Tests.Filter(sysFilter)),
       // Add a global resource directory with compile/ and test/ for resources in all projects
-      unmanagedResourceDirectories in Compile ++= Seq(
-        (baseDirectory in ThisBuild).value / "resources" / "compile"
+      Compile / unmanagedResourceDirectories ++= Seq(
+        (ThisBuild / baseDirectory).value / "resources" / "compile"
       ),
-      unmanagedResourceDirectories in Test ++= Seq(
-        (baseDirectory in ThisBuild).value / "resources" / "test"
+      Test / unmanagedResourceDirectories ++= Seq(
+        (ThisBuild / baseDirectory).value / "resources" / "test"
       ),
-      resourceGenerators in Compile += Def.task {
-        val inputFile = (deliverLocal in Compile).value
-        val outputFile = (resourceManaged in Compile).value / s"${name.value}-ivy.xml"
+      Compile / resourceGenerators += Def.task {
+        val inputFile = (Compile / deliverLocal).value
+        val outputFile = (Compile / resourceManaged).value / s"${name.value}-ivy.xml"
         streams.value.log.info(s"Copying ${inputFile.getPath} to ${outputFile.getPath}")
         IO.copyFile(inputFile, outputFile)
         Seq(outputFile)

--- a/protocol/build.sbt
+++ b/protocol/build.sbt
@@ -19,9 +19,7 @@
 // JSON DEPENDENCIES
 //
 libraryDependencies ++= Seq(
-  Dependencies.playJson excludeAll(
-    ExclusionRule(organization = "com.fasterxml.jackson.core")
-  ),
+  Dependencies.playJson excludeAll ExclusionRule(organization = "com.fasterxml.jackson.core"),
   Dependencies.jacksonDatabind,
   Dependencies.slf4jApi
 )


### PR DESCRIPTION
Migrate the sbt script from deprecated syntax to slash syntax, to suppress build warnings.
```
[warn] /Users/chengpan/Projects/apache-toree/project/CommonPlugin.scala:37:19: method in in trait ScopingSetting is deprecated (since 1.5.0): `in` is deprecated; migrate to slash syntax - https://www.scala-sbt.org/1.x/docs/Migrating-from-sbt-013x.html#slash
[warn]       testOptions in UnitTest := Seq(Tests.Filter(unitFilter)),
[warn]                   ^
```