### PR TITLE
[TOREE-538] apache/toree-dev image supports Applie Silicon

### DIFF
--- a/Dockerfile.toree-dev
+++ b/Dockerfile.toree-dev
@@ -30,7 +30,8 @@ RUN apt-get -y update && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* && \
     update-ca-certificates -f && \
-    update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java
+    JAVA_8=`update-alternatives --list java | grep java-8-openjdk` && \
+    update-alternatives --set java $JAVA_8
 
 # Installing Spark3
 RUN cd /tmp && \


### PR DESCRIPTION
I got failures when running `make dev` on M1 chips MacBook
```
29.95 update-alternatives: error: alternative /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java for java not registered; not setting
```

because for ARM platform, the installed OpenJDK 8 path is `/usr/lib/jvm/java-8-openjdk-arm64` instead of `/usr/lib/jvm/java-8-openjdk-amd64`.

I verified this change locally by run `make dev` on my M1 MacBook, and the CI should verify the change works on x86 platform.