### PR TITLE
[TOREE-539] Exclude pyenv setting files from git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 
 # Python
 **/*__pycache__
+.python-version
 
 # Notebooks
 !etc/**/*.ipynb


### PR DESCRIPTION
I'm using [pyenv-virtualenv](https://github.com/pyenv/pyenv-virtualenv) to manage the Python virtual environment.

> `.python-version` files are used by pyenv to denote local Python versions ...

ref: https://github.com/pyenv/pyenv-virtualenv#activate-virtualenv