### PR TITLE
[TOREE-543] Fix and enable JVMReprSpec

### DIFF
--- a/scala-interpreter/build.sbt
+++ b/scala-interpreter/build.sbt
@@ -17,5 +17,6 @@ import sbt.Tests.{Group, SubProcess}
  *  limitations under the License
  */
 
+Test / fork := true
 libraryDependencies ++= Dependencies.sparkAll.value
 libraryDependencies += "com.github.jupyter" % "jvm-repr" % "0.1.0"

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -155,7 +155,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
      doQuietly {
 
        bind(
-         "kernel", "org.apache.toree.kernel.api.Kernel",
+         "kernel", "org.apache.toree.kernel.api.KernelLike",
          kernel, List( """@transient implicit""")
        )
      }

--- a/scala-interpreter/src/test/scala/integration/interpreter/scala/JVMReprSpec.scala
+++ b/scala-interpreter/src/test/scala/integration/interpreter/scala/JVMReprSpec.scala
@@ -28,13 +28,12 @@ import org.apache.toree.interpreter.Results.Success
 import org.apache.toree.kernel.api.{DisplayMethodsLike, KernelLike}
 import org.apache.toree.kernel.interpreter.scala.ScalaInterpreter
 import org.mockito.Mockito.doReturn
-import org.scalatest.{BeforeAndAfter, FunSpec, Ignore, Matchers}
+import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.Random
 
 @SbtForked
-@Ignore
 class JVMReprSpec extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter {
 
   private val outputResult = new ByteArrayOutputStream()


### PR DESCRIPTION
This PR fixes and enables `JVMReprSpec` by doing the following things 

1. Fix the binding issue by changing `Kernel` to `KernelLike`, as the provided instance is `mock[KernelLike]`, the `Kernel` causes assignment failure

```
23/08/10 00:09:16 ERROR ScalaInterpreter: Set failed in bind(kernel, org.apache.toree.kernel.api.Kernel, Mock for KernelLike, hashCode: 381550865)
23/08/10 00:09:16 ERROR ScalaInterpreter: scala.tools.nsc.interpreter.IMain$ReadEvalPrint$EvalException: Failed to load '$line4.$eval': $line4.$eval
        at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.evalError(IMain.scala:757)
        at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.load(IMain.scala:761)
        at scala.tools.nsc.interpreter.IMain$ReadEvalPrint.evalClass$lzycompute(IMain.scala:764)
...
```

2. execute tests using fork mode in scala-interpreter module. I suppose the original author aims to do that since there is `SbtForked`, but unfortunately, it does not work. Without change, the test will fail in a weird way. (I struggled for a few days, but did not find the root cause, just found switching to fork mode could fix it.)
```
[info] integration.interpreter.scala.JVMReprSpec *** ABORTED *** (861 milliseconds)
[info]   java.lang.AssertionError: assertion failed: 
[info]   No RuntimeVisibleAnnotations in classfile with ScalaSignature attribute: package object collection
[info]      while compiling: <no file>
[info]         during phase: globalPhase=<no phase>, enteringPhase=<some phase>
[info]      library version: version 2.12.15
[info]     compiler version: version 2.12.15
...
```

3. Remove the `Ignore` of `JVMReprSpec` to re-enable this test.