### PR TITLE
[TOREE-545] Upgrade Scalatest 3.2 and Mockito 4

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -77,7 +77,8 @@ ThisBuild / resolvers ++= Seq(
 ThisBuild / updateOptions := updateOptions.value.withCachedResolution(true)
 ThisBuild / libraryDependencies ++= Seq(
   Dependencies.scalaTest % "test",
-  Dependencies.mockito % "test",
+  Dependencies.scalaTestMockito % "test",
+  Dependencies.mockitoInline % "test",
   Dependencies.jacksonDatabind % "test"
 )
 

--- a/client/src/test/scala/integration/unused.integration.socket/ClientToHeartbeatSpecForIntegration.scala
+++ b/client/src/test/scala/integration/unused.integration.socket/ClientToHeartbeatSpecForIntegration.scala
@@ -31,15 +31,16 @@ import org.apache.toree.kernel.protocol.v5.SocketType
 import org.apache.toree.kernel.protocol.v5.socket._
 import org.apache.toree.kernel.protocol.v5.socket.SocketConfig
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import scala.concurrent.duration._
 
 
 class ClientToHeartbeatSpecForIntegration extends TestKit(ActorSystem("HeartbeatActorSpec"))
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
 
   describe("HeartbeatActor") {
     implicit val timeout = Timeout(1.minute)

--- a/client/src/test/scala/integration/unused.integration.socket/ClientToIOPubSpecForIntegration.scala
+++ b/client/src/test/scala/integration/unused.integration.socket/ClientToIOPubSpecForIntegration.scala
@@ -27,16 +27,17 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content.ExecuteResult
 import org.apache.toree.kernel.protocol.v5.socket._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
 
 class ClientToIOPubSpecForIntegration extends TestKit(ActorSystem("IOPubSystem"))
-with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   describe("Client-IOPub Integration"){
     describe("Client"){
       it("should connect to IOPub Socket"){

--- a/client/src/test/scala/integration/unused.integration.socket/ClientToShellSpecForIntegration.scala
+++ b/client/src/test/scala/integration/unused.integration.socket/ClientToShellSpecForIntegration.scala
@@ -28,14 +28,15 @@ import akka.zeromq._
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content.ExecuteRequest
 import org.apache.toree.kernel.protocol.v5.socket._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 
 class ClientToShellSpecForIntegration extends TestKit(ActorSystem("ShellActorSpec"))
-with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   describe("ShellActor") {
     val clientSocketFactory = mock[ClientSocketFactory]
     val serverSocketFactory = mock[ServerSocketFactory]

--- a/client/src/test/scala/org/apache/toree/comm/ClientCommManagerSpec.scala
+++ b/client/src/test/scala/org/apache/toree/comm/ClientCommManagerSpec.scala
@@ -23,10 +23,12 @@ import org.apache.toree.kernel.protocol.v5.client.ActorLoader
 import org.apache.toree.kernel.protocol.v5.content.CommContent
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers._
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.mockito.ArgumentMatchers._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ClientCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
+class ClientCommManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach
   with MockitoSugar
 {
   private val TestTargetName = "some target"
@@ -38,7 +40,7 @@ class ClientCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
 
   private var generatedCommWriter: CommWriter = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockActorLoader = mock[ActorLoader]
     mockKMBuilder = mock[KMBuilder]
     mockCommRegistrar = mock[CommRegistrar]
@@ -53,7 +55,7 @@ class ClientCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
 
         generatedCommWriter = commWriter
 
-        val spyCommWriter = spy(commWriter)
+        val spyCommWriter = spy[CommWriter](commWriter)
         doNothing().when(spyCommWriter)
           .sendCommKernelMessage(any[KernelMessageContent with CommContent])
 

--- a/client/src/test/scala/org/apache/toree/comm/ClientCommWriterSpec.scala
+++ b/client/src/test/scala/org/apache/toree/comm/ClientCommWriterSpec.scala
@@ -25,10 +25,12 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.client.ActorLoader
 import org.apache.toree.kernel.protocol.v5.content._
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
@@ -43,7 +45,7 @@ object ClientCommWriterSpec {
 class ClientCommWriterSpec extends TestKit(
   ActorSystem("ClientCommWriterSpec",
     ConfigFactory.parseString(ClientCommWriterSpec.config))
-) with FunSpecLike with Matchers with BeforeAndAfter with MockitoSugar
+) with AnyFunSpecLike with Matchers with BeforeAndAfterEach with MockitoSugar
 {
 
   private val commId = UUID.randomUUID().toString
@@ -84,15 +86,15 @@ class ClientCommWriterSpec extends TestKit(
     Json.parse(receivedMessage.contentString).as[T]
   }
 
-  before {
-    kernelMessageBuilder = spy(KMBuilder())
+  override def beforeEach(): Unit = {
+    kernelMessageBuilder = spy[KMBuilder](KMBuilder())
 
     // Construct path for kernel message relay
     actorLoader = mock[ActorLoader]
     shellSocketProbe = TestProbe()
     val shellSocketSelection: ActorSelection =
       system.actorSelection(shellSocketProbe.ref.path.toString)
-    doReturn(shellSocketSelection)
+    doReturn(shellSocketSelection, Nil: _*)
       .when(actorLoader).load(SocketType.ShellClient)
 
     // Create a new writer to use for testing

--- a/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/SparkKernelClientSpec.scala
+++ b/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/SparkKernelClientSpec.scala
@@ -25,13 +25,15 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.client.execution.ExecuteRequestTuple
 import scala.concurrent.duration._
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 
 class SparkKernelClientSpec
   extends TestKit(ActorSystem("SparkKernelClientActorSystem"))
-  with Matchers with MockitoSugar with FunSpecLike with BeforeAndAfter
+  with Matchers with MockitoSugar with AnyFunSpecLike with BeforeAndAfterEach
 {
   private val TestTargetName = "some target"
 
@@ -41,7 +43,7 @@ class SparkKernelClientSpec
   private var executeRequestProbe: TestProbe = _
   private var shellClientProbe: TestProbe = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockActorLoader = mock[ActorLoader]
     mockCommRegistrar = mock[CommRegistrar]
 

--- a/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/execution/DeferredExecutionTest.scala
+++ b/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/execution/DeferredExecutionTest.scala
@@ -20,7 +20,8 @@ package org.apache.toree.kernel.protocol.v5.client.execution
 import org.apache.toree.kernel.protocol.v5.content.{StreamContent, ExecuteResult}
 import org.apache.toree.kernel.protocol.v5.content._
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.Promise
@@ -64,7 +65,7 @@ object DeferredExecutionTest {
 class ExecuteResultPromise {}
 class ExecuteReplyPromise {}
 
-class DeferredExecutionTest extends FunSpec with ScalaFutures with Matchers {
+class DeferredExecutionTest extends AnyFunSpec with ScalaFutures with Matchers {
   import DeferredExecutionTest._
   describe("DeferredExecution") {
     describe("onResult( callback )"){

--- a/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/HeartbeatClientSpec.scala
+++ b/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/HeartbeatClientSpec.scala
@@ -22,12 +22,13 @@ import akka.testkit.{TestProbe, ImplicitSender, TestKit}
 import org.apache.toree.communication.ZMQMessage
 import org.apache.toree.kernel.protocol.v5.client.ActorLoader
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Matchers, FunSpecLike}
-import org.mockito.Matchers._
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
 class HeartbeatClientSpec extends TestKit(ActorSystem("HeartbeatActorSpec"))
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
 
   describe("HeartbeatClientActor") {
     val socketFactory = mock[SocketFactory]

--- a/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/IOPubClientSpec.scala
+++ b/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/IOPubClientSpec.scala
@@ -32,12 +32,14 @@ import org.apache.toree.kernel.protocol.v5.client.execution.{DeferredExecution, 
 import org.apache.toree.kernel.protocol.v5.client.{ActorLoader, Utilities}
 import org.apache.toree.kernel.protocol.v5.content.{CommClose, CommMsg, CommOpen, StreamContent}
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{Eventually, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Milliseconds, Span}
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
@@ -53,8 +55,8 @@ object IOPubClientSpec {
 
 class IOPubClientSpec extends TestKit(ActorSystem(
   "IOPubClientSpecSystem", ConfigFactory.parseString(IOPubClientSpec.config)
-)) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with ScalaFutures with BeforeAndAfter with Eventually
+)) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with ScalaFutures with BeforeAndAfterEach with Eventually
 {
   private val TestTimeout = Timeout(10.seconds)
   implicit override val patienceConfig = PatienceConfig(
@@ -77,19 +79,19 @@ class IOPubClientSpec extends TestKit(ActorSystem(
   private val TestTargetName = "some target"
   private val TestCommId = UUID.randomUUID().toString
 
-  before {
+  override def beforeEach(): Unit = {
     kmBuilder = KMBuilder()
     mockCommCallbacks = mock[CommCallbacks]
     mockCommRegistrar = mock[CommRegistrar]
 
-    spyCommStorage = spy(new CommStorage())
+    spyCommStorage = spy[CommStorage](new CommStorage())
 
     clientSocketProbe = TestProbe()
     mockActorLoader = mock[ActorLoader]
     mockClientSocketFactory = mock[SocketFactory]
 
     //  Stub the return value for the socket factory
-    when(mockClientSocketFactory.IOPubClient(anyObject(), any[ActorRef]))
+    when(mockClientSocketFactory.IOPubClient(any[ActorSystem](), any[ActorRef]))
       .thenReturn(clientSocketProbe.ref)
 
     //  Construct the object we will test against
@@ -108,7 +110,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           .build
 
         // Mark as target being provided
-        doReturn(Some(mockCommCallbacks)).when(spyCommStorage)
+        doReturn(Some(mockCommCallbacks), Nil: _*).when(spyCommStorage)
           .getTargetCallbacks(anyString())
 
         // Simulate receiving a message from the kernel
@@ -129,7 +131,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           .build
 
         // Mark as target NOT being provided
-        doReturn(None).when(spyCommStorage).getTargetCallbacks(anyString())
+        doReturn(None, Nil: _*).when(spyCommStorage).getTargetCallbacks(anyString())
 
         // Simulate receiving a message from the kernel
         ioPubClient ! message
@@ -153,7 +155,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           .build
 
         // Mark as target being provided
-        doReturn(Some(mockCommCallbacks)).when(spyCommStorage)
+        doReturn(Some(mockCommCallbacks), Nil: _*).when(spyCommStorage)
           .getCommIdCallbacks(any[v5.UUID])
 
         // Simulate receiving a message from the kernel
@@ -173,7 +175,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           .build
 
         // Mark as target NOT being provided
-        doReturn(None).when(spyCommStorage).getCommIdCallbacks(any[v5.UUID])
+        doReturn(None, Nil: _*).when(spyCommStorage).getCommIdCallbacks(any[v5.UUID])
 
         // Simulate receiving a message from the kernel
         ioPubClient ! message
@@ -195,7 +197,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           .build
 
         // Mark as target being provided
-        doReturn(Some(mockCommCallbacks)).when(spyCommStorage)
+        doReturn(Some(mockCommCallbacks), Nil: _*).when(spyCommStorage)
           .getCommIdCallbacks(any[v5.UUID])
 
         // Simulate receiving a message from the kernel
@@ -215,7 +217,7 @@ class IOPubClientSpec extends TestKit(ActorSystem(
           .build
 
         // Mark as target NOT being provided
-        doReturn(None).when(spyCommStorage).getCommIdCallbacks(any[v5.UUID])
+        doReturn(None, Nil: _*).when(spyCommStorage).getCommIdCallbacks(any[v5.UUID])
 
         // Simulate receiving a message from the kernel
         ioPubClient ! message

--- a/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/ShellClientSpec.scala
+++ b/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/ShellClientSpec.scala
@@ -27,13 +27,14 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.client.ActorLoader
 import org.apache.toree.kernel.protocol.v5.content.ExecuteRequest
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Matchers, FunSpecLike}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import play.api.libs.json.Json
 
 class ShellClientSpec extends TestKit(ActorSystem("ShellActorSpec"))
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   private val SignatureEnabled = true
 
   describe("ShellClientActor") {
@@ -45,7 +46,7 @@ class ShellClientSpec extends TestKit(ActorSystem("ShellActorSpec"))
     )).thenReturn(probe.ref)
 
     val signatureManagerProbe = TestProbe()
-    doReturn(system.actorSelection(signatureManagerProbe.ref.path.toString))
+    doReturn(system.actorSelection(signatureManagerProbe.ref.path.toString), Nil: _*)
       .when(mockActorLoader).load(SecurityActorType.SignatureManager)
 
     val shellClient = system.actorOf(Props(

--- a/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/StdinClientSpec.scala
+++ b/client/src/test/scala/org/apache/toree/kernel/protocol/v5/client/socket/StdinClientSpec.scala
@@ -26,17 +26,19 @@ import org.apache.toree.kernel.protocol.v5.client.ActorLoader
 import org.apache.toree.kernel.protocol.v5.client.socket.StdinClient.{ResponseFunctionMessage, ResponseFunction}
 import org.apache.toree.kernel.protocol.v5.content.{InputReply, InputRequest, ClearOutput, ExecuteRequest}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import org.apache.toree.kernel.protocol.v5.client.Utilities._
 import play.api.libs.json.Json
 import scala.concurrent.duration._
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 class StdinClientSpec extends TestKit(ActorSystem("StdinActorSpec"))
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   private val SignatureEnabled = true
   private val TestReplyString = "some value"
@@ -48,14 +50,14 @@ class StdinClientSpec extends TestKit(ActorSystem("StdinActorSpec"))
   private var socketProbe: TestProbe = _
   private var stdinClient: ActorRef = _
 
-  before {
+  override def beforeEach(): Unit = {
     socketProbe = TestProbe()
     signatureManagerProbe = TestProbe()
     mockSocketFactory = mock[SocketFactory]
     mockActorLoader = mock[ActorLoader]
-    doReturn(system.actorSelection(signatureManagerProbe.ref.path.toString))
+    doReturn(system.actorSelection(signatureManagerProbe.ref.path.toString), Nil: _*)
       .when(mockActorLoader).load(SecurityActorType.SignatureManager)
-    doReturn(socketProbe.ref).when(mockSocketFactory)
+    doReturn(socketProbe.ref, Nil: _*).when(mockSocketFactory)
       .StdinClient(any[ActorSystem], any[ActorRef])
 
     stdinClient = system.actorOf(Props(

--- a/client/src/test/scala/system/ClientCommSpecForSystem.scala
+++ b/client/src/test/scala/system/ClientCommSpecForSystem.scala
@@ -26,7 +26,9 @@ import org.apache.toree.kernel.protocol.v5.{KMBuilder, KernelMessage, SocketType
 import org.scalatest.concurrent.Eventually
 import org.scalatest.exceptions.TestFailedDueToTimeoutException
 import org.scalatest.time.{Milliseconds, Seconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FunSpecLike, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 import test.utils.SparkClientDeployer
 
@@ -41,8 +43,8 @@ import scala.concurrent.duration._
  */
 class ClientCommSpecForSystem
   extends TestKit(SparkClientDeployer.getClientActorSystem)
-  with FunSpecLike with Matchers with BeforeAndAfterAll with Eventually
-{
+  with AnyFunSpecLike with Matchers with BeforeAndAfterAll with Eventually {
+
   private val MaxFishTime = 2.seconds
   implicit override val patienceConfig = PatienceConfig(
     timeout = scaled(Span(2, Seconds)),

--- a/client/src/test/scala/test/utils/SparkClientDeployer.scala
+++ b/client/src/test/scala/test/utils/SparkClientDeployer.scala
@@ -164,7 +164,7 @@ object SparkClientDeployer extends LogLike{
    *
    * @return The actor system of ClientBootstrap
    */
-  def getClientActorSystem: ActorSystem =
+  def getClientActorSystem(): ActorSystem =
     if (testActorSystem == null) { client; testActorSystem }
     else testActorSystem
 }

--- a/communication/src/test/scala/integration/JeroMQSocketIntegrationSpec.scala
+++ b/communication/src/test/scala/integration/JeroMQSocketIntegrationSpec.scala
@@ -22,11 +22,13 @@ import java.util.concurrent.ConcurrentLinkedDeque
 import org.apache.toree.communication.SocketManager
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Milliseconds, Span}
-import org.scalatest.{Matchers, OneInstancePerTest, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.zeromq.ZMQ.Context
 import org.zeromq.{ZMsg, ZMQ}
 
-class JeroMQSocketIntegrationSpec extends FunSpec
+class JeroMQSocketIntegrationSpec extends AnyFunSpec
   with OneInstancePerTest with Matchers with Eventually {
   implicit override val patienceConfig = PatienceConfig(
     timeout = scaled(Span(800, Milliseconds)),

--- a/communication/src/test/scala/integration/security/SignatureCheckerActorSpecForIntegration.scala
+++ b/communication/src/test/scala/integration/security/SignatureCheckerActorSpecForIntegration.scala
@@ -22,7 +22,9 @@ import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.communication.security.{Hmac, SignatureCheckerActor}
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 
 object SignatureCheckerActorSpecForIntegration {
@@ -37,7 +39,7 @@ class SignatureCheckerActorSpecForIntegration extends TestKit(
     "SignatureCheckerActorSpec",
     ConfigFactory.parseString(SignatureCheckerActorSpecForIntegration.config)
   )
-) with ImplicitSender with FunSpecLike with Matchers with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with BeforeAndAfterEach
 {
 
   private val sigKey = "12345"
@@ -62,13 +64,13 @@ class SignatureCheckerActorSpecForIntegration extends TestKit(
 
   private var signatureChecker: ActorRef = _
 
-  before {
+  override def beforeEach(): Unit = {
     val hmac = Hmac(sigKey)
     signatureChecker =
       system.actorOf(Props(classOf[SignatureCheckerActor], hmac))
   }
 
-  after {
+  override def afterEach(): Unit = {
     signatureChecker = null
   }
 

--- a/communication/src/test/scala/integration/security/SignatureManagerActorSpecForIntegration.scala
+++ b/communication/src/test/scala/integration/security/SignatureManagerActorSpecForIntegration.scala
@@ -22,7 +22,9 @@ import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.toree.communication.security.SignatureManagerActor
 import org.apache.toree.kernel.protocol.v5.{KernelMessage, _}
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
@@ -39,7 +41,7 @@ class SignatureManagerActorSpecForIntegration extends TestKit(
     "SignatureManagerActorSpec",
     ConfigFactory.parseString(SignatureManagerActorSpecForIntegration.config)
   )
-) with ImplicitSender with FunSpecLike with Matchers with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with BeforeAndAfterEach
 {
   private val IncomingMessageType = "d" // Needed for valid signature
   
@@ -66,7 +68,7 @@ class SignatureManagerActorSpecForIntegration extends TestKit(
   private var signatureManager: ActorRef = _
   private var signatureManagerWithNoIncoming: ActorRef = _
 
-  before {
+  override def beforeEach(): Unit = {
     signatureManager =
       system.actorOf(Props(
         classOf[SignatureManagerActor], sigKey
@@ -78,7 +80,7 @@ class SignatureManagerActorSpecForIntegration extends TestKit(
       ))
   }
 
-  after {
+  override def afterEach(): Unit = {
     signatureManager = null
   }
 

--- a/communication/src/test/scala/integration/security/SignatureProducerActorSpecForIntegration.scala
+++ b/communication/src/test/scala/integration/security/SignatureProducerActorSpecForIntegration.scala
@@ -22,7 +22,9 @@ import akka.testkit.{ImplicitSender, TestKit}
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.communication.security.{Hmac, SignatureProducerActor}
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 
 object SignatureProducerActorSpecForIntegration {
   val config = """
@@ -36,21 +38,21 @@ class SignatureProducerActorSpecForIntegration extends TestKit(
     "SignatureProducerActorSpec",
     ConfigFactory.parseString(SignatureProducerActorSpecForIntegration.config)
   )
-) with ImplicitSender with FunSpecLike with Matchers with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with BeforeAndAfterEach
 {
 
   private val sigKey = "12345"
 
   private var signatureProducer: ActorRef = _
 
-  before {
+  override def beforeEach(): Unit = {
     val hmac = Hmac(sigKey)
     signatureProducer =
       system.actorOf(Props(classOf[SignatureProducerActor], hmac))
 
   }
 
-  after {
+  override def afterEach(): Unit = {
     signatureProducer = null
   }
 

--- a/communication/src/test/scala/org/apache/toree/communication/security/HmacSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/security/HmacSpec.scala
@@ -19,9 +19,10 @@ package org.apache.toree.communication.security
 
 import java.security.NoSuchAlgorithmException
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class HmacSpec extends FunSpec with Matchers {
+class HmacSpec extends AnyFunSpec with Matchers {
   describe("Hmac Object") {
     describe("#apply") {
       it("should fail if the algorithm is not available") {

--- a/communication/src/test/scala/org/apache/toree/communication/socket/JeroMQSocketSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/socket/JeroMQSocketSpec.scala
@@ -18,13 +18,16 @@ package org.apache.toree.communication.socket
 
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
-import org.scalatest.{Matchers, BeforeAndAfter, OneInstancePerTest, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
 import org.zeromq.ZMsg
 
-class JeroMQSocketSpec extends FunSpec with MockitoSugar
-  with OneInstancePerTest with BeforeAndAfter with Matchers
+class JeroMQSocketSpec extends AnyFunSpec with MockitoSugar
+  with OneInstancePerTest with BeforeAndAfterEach with Matchers
 {
   private val runnable = mock[ZeroMQSocketRunnable]
   @volatile private var running = true
@@ -43,7 +46,7 @@ class JeroMQSocketSpec extends FunSpec with MockitoSugar
 
   private val socket: JeroMQSocket = new JeroMQSocket(runnable)
 
-  after {
+  override def afterEach(): Unit = {
     running = false
   }
 

--- a/communication/src/test/scala/org/apache/toree/communication/utils/OrderedSupportSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/utils/OrderedSupportSpec.scala
@@ -20,7 +20,8 @@ package org.apache.toree.communication.utils
 import akka.actor._
 import akka.testkit.{ImplicitSender, TestKit}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 
 case class OrderedType()
 case class NotOrderedType()
@@ -45,7 +46,7 @@ class TestOrderedSupport extends OrderedSupport {
 }
 
 class OrderedSupportSpec extends TestKit(ActorSystem("OrderedSupportSystem"))
-  with ImplicitSender with Matchers with FunSpecLike
+  with ImplicitSender with Matchers with AnyFunSpecLike
   with MockitoSugar  {
 
   describe("OrderedSupport"){

--- a/kernel-api/src/test/scala/org/apache/toree/dependencies/CoursierDependencyDownloaderSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/dependencies/CoursierDependencyDownloaderSpec.scala
@@ -19,9 +19,11 @@ package org.apache.toree.dependencies
 import java.net.URL
 import java.nio.file.Files
 
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class CoursierDependencyDownloaderSpec extends FunSpec with Matchers
+class CoursierDependencyDownloaderSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest
 {
   private val coursierDependencyDownloader = new CoursierDependencyDownloader

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerBridgeSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerBridgeSpec.scala
@@ -18,9 +18,11 @@ package org.apache.toree.interpreter.broker
 
 import org.apache.toree.kernel.api.KernelLike
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class BrokerBridgeSpec extends FunSpec with Matchers with OneInstancePerTest
+class BrokerBridgeSpec extends AnyFunSpec with Matchers with OneInstancePerTest
   with MockitoSugar
 {
   private val mockBrokerState = mock[BrokerState]

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerProcessHandlerSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerProcessHandlerSpec.scala
@@ -18,11 +18,13 @@ package org.apache.toree.interpreter.broker
 
 import org.apache.commons.exec.ExecuteException
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
-class BrokerProcessHandlerSpec extends FunSpec with Matchers
+class BrokerProcessHandlerSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest with MockitoSugar
 {
   private val mockBrokerBridge = mock[BrokerBridge]

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerProcessSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerProcessSpec.scala
@@ -22,12 +22,14 @@ import org.apache.commons.exec._
 import org.apache.commons.io.FilenameUtils
 import org.mockito.ArgumentCaptor
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
-class BrokerProcessSpec extends FunSpec with Matchers
+class BrokerProcessSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest with MockitoSugar
 {
   private val TestProcessName = "test_process"
@@ -233,7 +235,7 @@ class BrokerProcessSpec extends FunSpec with Matchers
         brokerProcess.start()
 
         val mockExecuteWatchdog = mock[ExecuteWatchdog]
-        doReturn(mockExecuteWatchdog).when(mockExecutor).getWatchdog
+        doReturn(mockExecuteWatchdog, Nil: _*).when(mockExecutor).getWatchdog
 
         brokerProcess.stop()
 
@@ -242,7 +244,7 @@ class BrokerProcessSpec extends FunSpec with Matchers
 
       it("should not try to destroy the process if it is not running") {
         val mockExecuteWatchdog = mock[ExecuteWatchdog]
-        doReturn(mockExecuteWatchdog).when(mockExecutor).getWatchdog
+        doReturn(mockExecuteWatchdog, Nil: _*).when(mockExecutor).getWatchdog
 
         brokerProcess.stop()
 

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerStateSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerStateSpec.scala
@@ -16,11 +16,13 @@
  */
 package org.apache.toree.interpreter.broker
 
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Success
 
-class BrokerStateSpec extends FunSpec with Matchers with OneInstancePerTest {
+class BrokerStateSpec extends AnyFunSpec with Matchers with OneInstancePerTest {
 
   private val TestMaxQueuedCode = 5
   private val brokerState = new BrokerState(TestMaxQueuedCode)

--- a/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerTransformerSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/interpreter/broker/BrokerTransformerSpec.scala
@@ -19,9 +19,11 @@ package org.apache.toree.interpreter.broker
 import org.apache.toree.interpreter.{ExecuteError, Results}
 import org.scalatest.concurrent.Eventually
 import scala.concurrent.Promise
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class BrokerTransformerSpec extends FunSpec with Matchers
+class BrokerTransformerSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest with Eventually
 {
   private val brokerTransformer = new BrokerTransformer

--- a/kernel-api/src/test/scala/org/apache/toree/magic/InternalClassLoaderSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/magic/InternalClassLoaderSpec.scala
@@ -17,10 +17,11 @@
 
 package org.apache.toree.magic
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-class InternalClassLoaderSpec extends FunSpec with Matchers with MockitoSugar {
+class InternalClassLoaderSpec extends AnyFunSpec with Matchers with MockitoSugar {
 
   abstract class MockClassLoader extends ClassLoader(null) {
     override def loadClass(name: String): Class[_] = null

--- a/kernel-api/src/test/scala/org/apache/toree/magic/MagicManagerSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/magic/MagicManagerSpec.scala
@@ -20,9 +20,11 @@ package org.apache.toree.magic
 import org.apache.toree.plugins.dependencies.Dependency
 import org.apache.toree.plugins._
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import test.utils
 
 import MagicManagerSpec._
@@ -60,12 +62,11 @@ private class ExceptionCellMagic extends CellMagic {
 }
 
 class MagicManagerSpec
-  extends FunSpec with Matchers with MockitoSugar with OneInstancePerTest
-{
+  extends AnyFunSpec with Matchers with MockitoSugar with OneInstancePerTest {
   private val TestPluginName = "SomePlugin"
   private val TestMagicName = "SomeMagic"
   private val mockPluginManager = mock[PluginManager]
-  private val magicManager = spy(new MagicManager(mockPluginManager))
+  private val magicManager = spy[MagicManager](new MagicManager(mockPluginManager))
 
   describe("MagicManager") {
     describe("#isLineMagic") {
@@ -75,7 +76,7 @@ class MagicManagerSpec
         val mockLineMagic = mock[LineMagic]
         val actual = magicManager.isLineMagic(mockLineMagic)
 
-        actual should be (expected)
+        actual should be(expected)
       }
 
       it("should return false if the magic does not extend the line magic interface") {
@@ -84,7 +85,7 @@ class MagicManagerSpec
         val mockMagic = mock[Magic]
         val actual = magicManager.isLineMagic(mockMagic)
 
-        actual should be (expected)
+        actual should be(expected)
       }
 
       it("should throw an exception if provided null") {
@@ -101,7 +102,7 @@ class MagicManagerSpec
         val mockCellMagic = mock[CellMagic]
         val actual = magicManager.isCellMagic(mockCellMagic)
 
-        actual should be (expected)
+        actual should be(expected)
       }
 
       it("should return false if the magic does not extend the cell magic interface") {
@@ -110,7 +111,7 @@ class MagicManagerSpec
         val mockMagic = mock[Magic]
         val actual = magicManager.isCellMagic(mockMagic)
 
-        actual should be (expected)
+        actual should be(expected)
       }
 
       it("should throw an exception if provided null") {
@@ -123,7 +124,7 @@ class MagicManagerSpec
     describe("#findMagic") {
       it("should throw a MagicNotFoundException if no magic matches the name") {
         intercept[MagicNotFoundException] {
-          doReturn(Seq(new Plugin {}).toIterable).when(mockPluginManager).plugins
+          doReturn(Seq(new Plugin {}).toIterable, Nil: _*).when(mockPluginManager).plugins
 
           magicManager.findMagic(TestMagicName)
         }
@@ -131,7 +132,7 @@ class MagicManagerSpec
 
       it("should throw a MagicNotFoundException if there are no loaded plugins") {
         intercept[MagicNotFoundException] {
-          doReturn(Nil).when(mockPluginManager).plugins
+          doReturn(Nil, Nil: _*).when(mockPluginManager).plugins
 
           magicManager.findMagic(TestMagicName)
         }
@@ -139,7 +140,7 @@ class MagicManagerSpec
 
       it("should throw a MagicNotFoundException if a plugin matches but is not a magic") {
         intercept[MagicNotFoundException] {
-          doReturn(Seq(new SomePlugin).toIterable).when(mockPluginManager).plugins
+          doReturn(Seq(new SomePlugin).toIterable, Nil: _*).when(mockPluginManager).plugins
 
           magicManager.findMagic(TestPluginName)
         }
@@ -148,29 +149,29 @@ class MagicManagerSpec
       it("should return the magic if exactly one is found") {
         val expected = new SomeMagic
 
-        doReturn(Seq(expected).toIterable).when(mockPluginManager).plugins
+        doReturn(Seq(expected).toIterable, Nil: _*).when(mockPluginManager).plugins
         val actual = magicManager.findMagic(TestMagicName)
 
-        actual should be (expected)
+        actual should be(expected)
       }
 
       it("should return a magic whose name matches even if casing is different") {
         val expected = new SomeMagic
 
-        doReturn(Seq(expected).toIterable).when(mockPluginManager).plugins
+        doReturn(Seq(expected).toIterable, Nil: _*).when(mockPluginManager).plugins
         val actual = magicManager.findMagic(TestMagicName.toUpperCase())
 
-        actual should be (expected)
+        actual should be(expected)
       }
 
       it("should return the first match if more than one magic matches the name") {
         val expected = new SomeMagic
 
-        doReturn(Seq(expected, new utils.SomeMagic).toIterable)
+        doReturn(Seq(expected, new utils.SomeMagic).toIterable, Nil: _*)
           .when(mockPluginManager).plugins
         val actual = magicManager.findMagic(TestMagicName)
 
-        actual should be (expected)
+        actual should be(expected)
       }
     }
 
@@ -179,13 +180,13 @@ class MagicManagerSpec
         doReturn(Some(FailurePluginMethodResult(
           mock[PluginMethod],
           new LineMagicException()
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         val result = magicManager.applyDynamic("TEST")()
 
-        result.asMap.get("text/plain") should not be(empty)
+        result.asMap.get("text/plain") should not be (empty)
       }
 
       it("should fire an event with the lowercase of the magic name") {
@@ -196,8 +197,8 @@ class MagicManagerSpec
         doReturn(Some(FailurePluginMethodResult(
           mock[PluginMethod],
           new LineMagicException()
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         magicManager.applyDynamic(pluginName)(arg :: Nil: _*)
@@ -212,8 +213,8 @@ class MagicManagerSpec
         doReturn(Some(FailurePluginMethodResult(
           mock[PluginMethod],
           new LineMagicException()
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         magicManager.applyDynamic(pluginName)(arg :: Nil: _*)
@@ -228,10 +229,9 @@ class MagicManagerSpec
         doReturn(Some(FailurePluginMethodResult(
           mock[PluginMethod],
           new LineMagicException()
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
-
         magicManager.applyDynamic(pluginName)(Nil: _*)
         verify(mockPluginManager).fireEventFirstResult(anyString(), mockEq(Seq(expected)): _*)
       }
@@ -243,8 +243,8 @@ class MagicManagerSpec
         doReturn(Some(SuccessPluginMethodResult(
           mock[PluginMethod],
           null
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         val result = magicManager.applyDynamic(pluginName)(Nil: _*)
@@ -258,8 +258,8 @@ class MagicManagerSpec
         doReturn(Some(SuccessPluginMethodResult(
           mock[PluginMethod],
           BoxedUnit.UNIT
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         val result = magicManager.applyDynamic(pluginName)(Nil: _*)
@@ -272,8 +272,8 @@ class MagicManagerSpec
         doReturn(Some(SuccessPluginMethodResult(
           mock[PluginMethod],
           cellMagicOutput
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         val result = magicManager.applyDynamic(pluginName)(Nil: _*)
@@ -286,8 +286,8 @@ class MagicManagerSpec
         doReturn(Some(SuccessPluginMethodResult(
           mock[PluginMethod],
           new AnyRef
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         val result = magicManager.applyDynamic(pluginName)(Nil: _*)
@@ -301,8 +301,8 @@ class MagicManagerSpec
         doReturn(Some(FailurePluginMethodResult(
           mock[PluginMethod],
           new Throwable
-        ))).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        )), Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
 
         val result = magicManager.applyDynamic(pluginName)(Nil: _*)
@@ -312,8 +312,8 @@ class MagicManagerSpec
       it("should throw a MagicNotFoundException when a magic cannot be found") {
         val pluginName = "THISMAGICDOESN'TEXIST"
 
-        doReturn(None).when(mockPluginManager).fireEventFirstResult(
-          anyString(), any(classOf[Dependency[_ <: AnyRef]])
+        doReturn(None, Nil: _*).when(mockPluginManager).fireEventFirstResult(
+          anyString(), any[Dependency[_ <: AnyRef]]()
         )
         intercept[MagicNotFoundException] {
           magicManager.applyDynamic(pluginName)(Nil: _*)

--- a/kernel-api/src/test/scala/org/apache/toree/utils/ArgumentParsingSupportSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/ArgumentParsingSupportSpec.scala
@@ -17,26 +17,28 @@
 
 package org.apache.toree.utils
 
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
-import joptsimple.{OptionSet, OptionSpec, OptionParser}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import joptsimple.{OptionSet, OptionParser}
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 import collection.JavaConverters._
 
-class ArgumentParsingSupportSpec extends FunSpec with Matchers
-  with BeforeAndAfter with MockitoSugar
+class ArgumentParsingSupportSpec extends AnyFunSpec with Matchers
+  with BeforeAndAfterEach with MockitoSugar
 {
   private var mockOptions: OptionSet = _
   private var mockParser: OptionParser = _
   private var argumentParsingInstance: ArgumentParsingSupport = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockOptions = mock[OptionSet]
     mockParser = mock[OptionParser]
-    doReturn(mockOptions).when(mockParser).parse(anyVararg[String]())
+    doReturn(mockOptions, Nil: _*).when(mockParser).parse(any[Array[String]](): _*)
 
     argumentParsingInstance = new Object() with ArgumentParsingSupport {
       override protected lazy val parser: OptionParser = mockParser
@@ -46,7 +48,7 @@ class ArgumentParsingSupportSpec extends FunSpec with Matchers
   describe("ArgumentParsingSupport") {
     describe("#parseArgs") {
       it("should invoke the underlying parser's parse method") {
-        doReturn(Nil.asJava).when(mockOptions).nonOptionArguments()
+        doReturn(Nil.asJava, Nil: _*).when(mockOptions).nonOptionArguments()
         argumentParsingInstance.parseArgs("")
 
         verify(mockParser).parse(anyString())
@@ -54,7 +56,7 @@ class ArgumentParsingSupportSpec extends FunSpec with Matchers
 
       it("should return an empty list if there are no non-option arguments") {
         val expected = Nil
-        doReturn(expected.asJava).when(mockOptions).nonOptionArguments()
+        doReturn(expected.asJava, Nil: _*).when(mockOptions).nonOptionArguments()
         val actual = argumentParsingInstance.parseArgs((
           "--transitive" :: expected
         ).mkString(" "))
@@ -64,7 +66,7 @@ class ArgumentParsingSupportSpec extends FunSpec with Matchers
 
       it("should return a list containing non-option arguments") {
         val expected = "non-option" :: Nil
-        doReturn(expected.asJava).when(mockOptions).nonOptionArguments()
+        doReturn(expected.asJava, Nil: _*).when(mockOptions).nonOptionArguments()
         val actual = argumentParsingInstance.parseArgs((
           "--transitive" :: expected
           ).mkString(" "))

--- a/kernel-api/src/test/scala/org/apache/toree/utils/ConditionalOutputStreamSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/ConditionalOutputStreamSpec.scala
@@ -21,10 +21,11 @@ import java.io.OutputStream
 
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers._
-import org.scalatest.{Matchers, FunSpec}
+import org.mockito.ArgumentMatchers._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ConditionalOutputStreamSpec extends FunSpec with Matchers with MockitoSugar {
+class ConditionalOutputStreamSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("ConditionalOutputStream") {
     describe("#()") {
       it("should throw an exception if the output stream is null") {

--- a/kernel-api/src/test/scala/org/apache/toree/utils/DownloadSupportSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/DownloadSupportSpec.scala
@@ -20,23 +20,25 @@ package org.apache.toree.utils
 import java.io.FileNotFoundException
 import java.net.URL
 
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import scala.io.Source
 import scala.tools.nsc.io.File
 
-class DownloadSupportSpec extends FunSpec with Matchers with BeforeAndAfter {
+class DownloadSupportSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach {
   val downloadDestinationUrl = new URL("file:///tmp/testfile2.ext")
 
   val testFileContent = "This is a test"
   val testFileName = "/tmp/testfile.txt"
 
   //  Create a test file for downloading
-  before {
+  override def beforeEach(): Unit = {
     File(testFileName).writeAll(testFileContent)
   }
 
   //  Cleanup what we made
-  after {
+  override def afterEach(): Unit = {
     if (File(testFileName).exists) File(testFileName).delete()
     if (File(downloadDestinationUrl.getPath).exists) File(downloadDestinationUrl.getPath).delete()
   }

--- a/kernel-api/src/test/scala/org/apache/toree/utils/DynamicReflectionSupportSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/DynamicReflectionSupportSpec.scala
@@ -19,13 +19,16 @@ package org.apache.toree.utils
 
 import java.io.OutputStream
 
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{GivenWhenThen, BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.GivenWhenThen
+import org.scalatest.BeforeAndAfter
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 class DynamicReflectionSupportSpec
-  extends FunSpec with Matchers with MockitoSugar {
+  extends AnyFunSpec with Matchers with MockitoSugar {
 
   describe("DynamicReflectionSupport") {
     describe("with a class instance") {

--- a/kernel-api/src/test/scala/org/apache/toree/utils/KeyValuePairUtilsSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/KeyValuePairUtilsSpec.scala
@@ -18,9 +18,10 @@
 package org.apache.toree.utils
 
 import joptsimple.util.KeyValuePair
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class KeyValuePairUtilsSpec extends FunSpec with Matchers {
+class KeyValuePairUtilsSpec extends AnyFunSpec with Matchers {
   private object TestKeyValuePair {
     def apply(key: String, value: String) = KeyValuePair.valueOf(s"$key=$value")
   }

--- a/kernel-api/src/test/scala/org/apache/toree/utils/MultiOutputStreamSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/MultiOutputStreamSpec.scala
@@ -20,12 +20,14 @@ package org.apache.toree.utils
 import java.io.OutputStream
 
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
-import org.mockito.Matchers._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 
 class MultiOutputStreamSpec
-  extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter {
+  extends AnyFunSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
 
   describe("MultiOutputStream") {
     val listOfMockOutputStreams = List(mock[OutputStream], mock[OutputStream])

--- a/kernel-api/src/test/scala/org/apache/toree/utils/ScheduledTaskManagerSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/ScheduledTaskManagerSpec.scala
@@ -23,9 +23,11 @@ import java.util.concurrent.{TimeUnit, CountDownLatch}
 
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Milliseconds, Span}
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ScheduledTaskManagerSpec extends FunSpec with Matchers with BeforeAndAfter
+class ScheduledTaskManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach
   with Eventually
 {
   private val TestTimeInterval = 30
@@ -81,12 +83,12 @@ class ScheduledTaskManagerSpec extends FunSpec with Matchers with BeforeAndAfter
     }
   }
 
-  before {
+  override def beforeEach(): Unit = {
     scheduledTaskManager = new ScheduledTaskManager
     scheduleVerifier = new ScheduleVerifier
   }
 
-  after {
+  override def afterEach(): Unit = {
     scheduledTaskManager.stop()
   }
 

--- a/kernel-api/src/test/scala/org/apache/toree/utils/TaskManagerSpec.scala
+++ b/kernel-api/src/test/scala/org/apache/toree/utils/TaskManagerSpec.scala
@@ -22,15 +22,17 @@ import java.util.concurrent.{ExecutionException, RejectedExecutionException}
 import org.scalatest.concurrent.PatienceConfiguration.Timeout
 import org.scalatest.concurrent.{Eventually, ScalaFutures, TimeLimits}
 import org.scalatest.time.{Milliseconds, Seconds, Span}
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import test.utils.UncaughtExceptionSuppression
 
 import scala.concurrent.Future
 import scala.runtime.BoxedUnit
 
-class TaskManagerSpec extends FunSpec with Matchers with MockitoSugar
-  with BeforeAndAfter with ScalaFutures with UncaughtExceptionSuppression
+class TaskManagerSpec extends AnyFunSpec with Matchers with MockitoSugar
+  with BeforeAndAfterEach with ScalaFutures with UncaughtExceptionSuppression
   with Eventually with TimeLimits
 {
   implicit override val patienceConfig = PatienceConfig(
@@ -40,11 +42,11 @@ class TaskManagerSpec extends FunSpec with Matchers with MockitoSugar
   private val MaxTestTasks = 50000
   private var taskManager: TaskManager = _
 
-  before {
+  override def beforeEach(): Unit = {
     taskManager = new TaskManager
   }
 
-  after {
+  override def afterEach(): Unit = {
     taskManager = null
   }
 

--- a/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
+++ b/kernel/src/test/scala/integration/InterpreterActorSpecForIntegration.scala
@@ -32,7 +32,9 @@ import org.apache.toree.kernel.protocol.v5.interpreter.tasks.InterpreterTaskFact
 import com.typesafe.config.ConfigFactory
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import test.utils.UncaughtExceptionSuppression
 import test.utils.MaxAkkaTestTimeout
 
@@ -49,7 +51,7 @@ class InterpreterActorSpecForIntegration extends TestKit(
     ConfigFactory.parseString(InterpreterActorSpecForIntegration.config),
     Main.getClass.getClassLoader
   )
-) with ImplicitSender with FunSpecLike with Matchers with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with BeforeAndAfterEach
   with MockitoSugar with UncaughtExceptionSuppression {
 
   private val output = new ByteArrayOutputStream()
@@ -58,12 +60,12 @@ class InterpreterActorSpecForIntegration extends TestKit(
   }
 
 
-  before {
+  override def beforeEach(): Unit = {
     output.reset()
     // interpreter.start()
     val mockDisplayMethods = mock[DisplayMethodsLike]
     val mockKernel = mock[KernelLike]
-    doReturn(mockDisplayMethods).when(mockKernel).display
+    doReturn(mockDisplayMethods, Nil: _*).when(mockKernel).display
     interpreter.init(mockKernel)
 
     interpreter.doQuietly({
@@ -75,7 +77,7 @@ class InterpreterActorSpecForIntegration extends TestKit(
     })
   }
 
-  after {
+  override def afterEach(): Unit = {
     //  context is shared so dont stop it
     //    context.stop()
     interpreter.stop()

--- a/kernel/src/test/scala/org/apache/toree/boot/CommandLineOptionsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/boot/CommandLineOptionsSpec.scala
@@ -21,11 +21,12 @@ import java.io.File
 
 import com.typesafe.config.Config
 import joptsimple.OptionException
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.JavaConverters._
 
-class CommandLineOptionsSpec extends FunSpec with Matchers {
+class CommandLineOptionsSpec extends AnyFunSpec with Matchers {
 
   describe("CommandLineOptions") {
     describe("when received --max-interpreter-threads=<int>") {

--- a/kernel/src/test/scala/org/apache/toree/comm/KernelCommManagerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/comm/KernelCommManagerSpec.scala
@@ -23,10 +23,12 @@ import org.apache.toree.kernel.protocol.v5.content.CommContent
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers._
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.mockito.ArgumentMatchers._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class KernelCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
+class KernelCommManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach
   with MockitoSugar
 {
   private val TestTargetName = "some target"
@@ -38,7 +40,7 @@ class KernelCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
 
   private var generatedCommWriter: CommWriter = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockActorLoader = mock[ActorLoader]
     mockKMBuilder = mock[KMBuilder]
     mockCommRegistrar = mock[CommRegistrar]
@@ -53,7 +55,7 @@ class KernelCommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
 
         generatedCommWriter = commWriter
 
-        val spyCommWriter = spy(commWriter)
+        val spyCommWriter = spy[CommWriter](commWriter)
         doNothing().when(spyCommWriter)
           .sendCommKernelMessage(any[KernelMessageContent with CommContent])
 

--- a/kernel/src/test/scala/org/apache/toree/comm/KernelCommWriterSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/comm/KernelCommWriterSpec.scala
@@ -27,9 +27,11 @@ import akka.actor.{ActorSelection, ActorSystem}
 import akka.testkit.{TestProbe, TestKit}
 import com.typesafe.config.ConfigFactory
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 object KernelCommWriterSpec {
   val config ="""
@@ -43,7 +45,7 @@ class KernelCommWriterSpec extends TestKit(
     ConfigFactory.parseString(KernelCommWriterSpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   )
-) with FunSpecLike with Matchers with BeforeAndAfter with MockitoSugar
+) with AnyFunSpecLike with Matchers with BeforeAndAfterEach with MockitoSugar
 {
 
   private val commId = UUID.randomUUID().toString
@@ -84,15 +86,15 @@ class KernelCommWriterSpec extends TestKit(
     Json.parse(receivedMessage.contentString).as[T]
   }
 
-  before {
-    kernelMessageBuilder = spy(KMBuilder())
+  override def beforeEach(): Unit = {
+    kernelMessageBuilder = spy[KMBuilder](KMBuilder())
 
     // Construct path for kernel message relay
     actorLoader = mock[ActorLoader]
     kernelMessageRelayProbe = TestProbe()
     val kernelMessageRelaySelection: ActorSelection =
       system.actorSelection(kernelMessageRelayProbe.ref.path.toString)
-    doReturn(kernelMessageRelaySelection)
+    doReturn(kernelMessageRelaySelection, Nil: _*)
       .when(actorLoader).load(SystemActorType.KernelMessageRelay)
 
     // Create a new writer to use for testing

--- a/kernel/src/test/scala/org/apache/toree/global/ExecutionCounterSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/global/ExecutionCounterSpec.scala
@@ -17,9 +17,10 @@
 
 package org.apache.toree.global
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ExecutionCounterSpec extends FunSpec with Matchers {
+class ExecutionCounterSpec extends AnyFunSpec with Matchers {
   describe("ExecutionCounter") {
     describe("#increment( String )"){
       it("should increment value when key is not present"){

--- a/kernel/src/test/scala/org/apache/toree/kernel/api/DisplayMethodsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/api/DisplayMethodsSpec.scala
@@ -23,7 +23,9 @@ import org.apache.toree.kernel.protocol.v5
 import org.apache.toree.kernel.protocol.v5.KernelMessage
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 import test.utils.MaxAkkaTestTimeout
 
@@ -32,8 +34,8 @@ class DisplayMethodsSpec extends TestKit(
     "DisplayMethodsSpec",
     None,
     Some(org.apache.toree.Main.getClass.getClassLoader)
-  )) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter
+  )) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   
 
@@ -43,17 +45,17 @@ class DisplayMethodsSpec extends TestKit(
   private var mockKernelMessage: v5.KernelMessage = _
   private var displayMethods: DisplayMethods = _
 
-  before {
+  override def beforeEach(): Unit = {
     kernelMessageRelayProbe = TestProbe()
 
     mockParentHeader = mock[v5.ParentHeader]
 
     mockActorLoader = mock[v5.kernel.ActorLoader]
-    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path))
+    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path), Nil: _*)
       .when(mockActorLoader).load(v5.SystemActorType.KernelMessageRelay)
 
     mockKernelMessage = mock[v5.KernelMessage]
-    doReturn(mockParentHeader).when(mockKernelMessage).header
+    doReturn(mockParentHeader, Nil: _*).when(mockKernelMessage).header
 
     displayMethods = new DisplayMethods(mockActorLoader, mockKernelMessage, v5.KMBuilder())
   }

--- a/kernel/src/test/scala/org/apache/toree/kernel/api/KernelSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/api/KernelSpec.scala
@@ -31,10 +31,12 @@ import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.plugins.PluginManager
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class KernelSpec extends FunSpec with Matchers with MockitoSugar
-  with BeforeAndAfter
+class KernelSpec extends AnyFunSpec with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   private val BadCode = Some("abc foo bar")
   private val GoodCode = Some("val foo = 1")
@@ -54,7 +56,7 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
   private var kernel: Kernel = _
   private var spyKernel: Kernel = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockConfig = mock[Config]
     mockInterpreter = mock[Interpreter]
     mockInterpreterManager = mock[InterpreterManager]
@@ -81,11 +83,11 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
       mockPluginManager
     )
 
-    spyKernel = spy(kernel)
+    spyKernel = spy[Kernel](kernel)
 
   }
 
-  after {
+  override def afterEach(): Unit = {
     ExecuteRequestState.reset()
   }
 
@@ -197,7 +199,7 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
 
       it("should create SparkConf") {
         val expected = "some value"
-        doReturn(expected).when(mockConfig).getString("spark.master")
+        doReturn(expected, Nil: _*).when(mockConfig).getString("spark.master")
 
         val sparkConf = kernel.createSparkConf(new SparkConf().setMaster(expected))
 
@@ -209,7 +211,7 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
 
       it("should use the specified timeout to initialize spark context") {
         val expectedTimeout: Long = 30000
-        doReturn(expectedTimeout).when(mockConfig).getDuration("spark_context_initialization_timeout", TimeUnit.MILLISECONDS)
+        doReturn(expectedTimeout, Nil: _*).when(mockConfig).getDuration("spark_context_initialization_timeout", TimeUnit.MILLISECONDS)
 
         kernel.getSparkContextInitializationTimeout should be(expectedTimeout)
       }
@@ -217,7 +219,7 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
       it("should throw an exception when negative value is specified as timeout") {
         intercept[RuntimeException] {
           val timeout: Long = -30000
-          doReturn(timeout).when(mockConfig).getDuration("spark_context_initialization_timeout", TimeUnit.MILLISECONDS)
+          doReturn(timeout, Nil: _*).when(mockConfig).getDuration("spark_context_initialization_timeout", TimeUnit.MILLISECONDS)
 
           kernel.getSparkContextInitializationTimeout
         }
@@ -226,7 +228,7 @@ class KernelSpec extends FunSpec with Matchers with MockitoSugar
       it("should throw an exception when zero is specified as timeout") {
         intercept[RuntimeException] {
           val timeout: Long = 0
-          doReturn(timeout).when(mockConfig).getDuration("spark_context_initialization_timeout", TimeUnit.MILLISECONDS)
+          doReturn(timeout, Nil: _*).when(mockConfig).getDuration("spark_context_initialization_timeout", TimeUnit.MILLISECONDS)
 
           kernel.getSparkContextInitializationTimeout
         }

--- a/kernel/src/test/scala/org/apache/toree/kernel/api/StreamMethodsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/api/StreamMethodsSpec.scala
@@ -22,7 +22,9 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.toree.kernel.protocol.v5
 import org.apache.toree.kernel.protocol.v5.KernelMessage
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, BeforeAndAfter, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 import test.utils.MaxAkkaTestTimeout
 import org.mockito.Mockito._
@@ -33,8 +35,8 @@ class StreamMethodsSpec extends TestKit(
     None,
     Some(org.apache.toree.Main.getClass.getClassLoader)
   )
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
 
   private var kernelMessageRelayProbe: TestProbe = _
@@ -43,17 +45,17 @@ class StreamMethodsSpec extends TestKit(
   private var mockKernelMessage: v5.KernelMessage = _
   private var streamMethods: StreamMethods = _
 
-  before {
+  override def beforeEach(): Unit = {
     kernelMessageRelayProbe = TestProbe()
 
     mockParentHeader = mock[v5.ParentHeader]
 
     mockActorLoader = mock[v5.kernel.ActorLoader]
-    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path))
+    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path), Nil: _*)
       .when(mockActorLoader).load(v5.SystemActorType.KernelMessageRelay)
 
     mockKernelMessage = mock[v5.KernelMessage]
-    doReturn(mockParentHeader).when(mockKernelMessage).header
+    doReturn(mockParentHeader, Nil: _*).when(mockKernelMessage).header
 
     streamMethods = new StreamMethods(mockActorLoader, mockKernelMessage)
   }

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/dispatch/StatusDispatchSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/dispatch/StatusDispatchSpec.scala
@@ -24,7 +24,9 @@ import org.apache.toree.kernel.protocol.v5.content.KernelStatus
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 import test.utils.MaxAkkaTestTimeout
 
@@ -35,10 +37,10 @@ class StatusDispatchSpec extends TestKit(
     Some(org.apache.toree.Main.getClass.getClassLoader)
   )
 )
-with FunSpecLike with Matchers with MockitoSugar with BeforeAndAfter{
+with AnyFunSpecLike with Matchers with MockitoSugar with BeforeAndAfterEach{
   var statusDispatchRef: ActorRef = _
   var relayProbe: TestProbe = _
-  before {
+  override def beforeEach(): Unit = {
     //  Mock the relay with a probe
     relayProbe = TestProbe()
     //  Mock the ActorLoader

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CodeCompleteHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CodeCompleteHandlerSpec.scala
@@ -18,21 +18,23 @@
 package org.apache.toree.kernel.protocol.v5.handler
 
 import akka.actor._
-import akka.testkit.{TestProbe, ImplicitSender, TestKit}
+import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.toree.Main
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content.CompleteRequest
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.kernel.protocol.v5Test._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, BeforeAndAfter, Matchers}
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpecLike
 import test.utils.MaxAkkaTestTimeout
 
 class CodeCompleteHandlerSpec extends TestKit(
   ActorSystem("CodeCompleteHandlerSpec", None, Some(Main.getClass.getClassLoader))
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter {
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach {
 
   var actorLoader: ActorLoader = _
   var handlerActor: ActorRef = _
@@ -40,7 +42,7 @@ class CodeCompleteHandlerSpec extends TestKit(
   var interpreterProbe: TestProbe = _
   var statusDispatchProbe: TestProbe = _
 
-  before {
+  override def beforeEach(): Unit = {
     actorLoader = mock[ActorLoader]
 
     handlerActor = system.actorOf(Props(classOf[CodeCompleteHandler], actorLoader))

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommInfoRequestHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommInfoRequestHandlerSpec.scala
@@ -25,10 +25,11 @@ import org.apache.toree.kernel.protocol.v5.content.CommInfoReply
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.kernel.protocol.v5.{Header, KernelMessage, Metadata, SystemActorType}
 import org.mockito.AdditionalMatchers.{not => mockNot}
-import org.mockito.Matchers.{eq => mockEq}
+import org.mockito.ArgumentMatchers.{eq => mockEq}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 
 import scala.concurrent.duration._
@@ -45,7 +46,7 @@ class CommInfoRequestHandlerSpec extends TestKit(
     ConfigFactory.parseString(CommInfoRequestHandlerSpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   )
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
 
   var WAIT_TIME = 2.seconds
 

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommMsgHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommMsgHandlerSpec.scala
@@ -26,16 +26,18 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.comm._
 import org.apache.toree.kernel.protocol.v5.content.{CommMsg, ClearOutput}
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import test.utils.MaxAkkaTestTimeout
 
 class CommMsgHandlerSpec extends TestKit(
   ActorSystem("CommMsgHandlerSpec", None, Some(Main.getClass.getClassLoader))
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   private val TestCommId = UUID.randomUUID().toString
 
@@ -47,10 +49,10 @@ class CommMsgHandlerSpec extends TestKit(
   private var kernelMessageRelayProbe: TestProbe = _
   private var statusDispatchProbe: TestProbe = _
 
-  before {
+  override def beforeEach(): Unit = {
     kmBuilder = KMBuilder()
     mockCommCallbacks = mock[CommCallbacks]
-    spyCommStorage = spy(new CommStorage())
+    spyCommStorage = spy[CommStorage](new CommStorage())
 
     mockActorLoader = mock[ActorLoader]
 
@@ -74,7 +76,7 @@ class CommMsgHandlerSpec extends TestKit(
     describe("#process") {
       it("should execute msg callbacks if the id is registered") {
         // Mark our id as registered
-        doReturn(Some(mockCommCallbacks)).when(spyCommStorage)
+        doReturn(Some(mockCommCallbacks), Nil: _*).when(spyCommStorage)
           .getCommIdCallbacks(TestCommId)
 
         // Send a comm_open message with the test target
@@ -93,7 +95,7 @@ class CommMsgHandlerSpec extends TestKit(
 
       it("should not execute msg callbacks if the id is not registered") {
         // Mark our target as not registered
-        doReturn(None).when(spyCommStorage).getCommIdCallbacks(TestCommId)
+        doReturn(None, Nil: _*).when(spyCommStorage).getCommIdCallbacks(TestCommId)
 
         // Send a comm_msg message with the test id
         commMsgHandler ! kmBuilder
@@ -131,7 +133,7 @@ class CommMsgHandlerSpec extends TestKit(
               v1.writeMsg(MsgData.Empty)
           }
         val callbacks = (new CommCallbacks).addMsgCallback(msgCallback)
-        doReturn(Some(callbacks)).when(spyCommStorage)
+        doReturn(Some(callbacks), Nil: _*).when(spyCommStorage)
           .getCommIdCallbacks(TestCommId)
 
         // Send a comm_msg message with the test id

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommOpenHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/CommOpenHandlerSpec.scala
@@ -29,15 +29,17 @@ import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.comm._
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import test.utils.MaxAkkaTestTimeout
 
 class CommOpenHandlerSpec extends TestKit(
   ActorSystem("CommOpenHandlerSpec", None, Some(Main.getClass.getClassLoader))
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   private val TestCommId = UUID.randomUUID().toString
   private val TestTargetName = "some test target"
@@ -51,10 +53,10 @@ class CommOpenHandlerSpec extends TestKit(
   private var kernelMessageRelayProbe: TestProbe = _
   private var statusDispatchProbe: TestProbe = _
 
-  before {
+  override def beforeEach(): Unit = {
     kmBuilder = KMBuilder()
     mockCommCallbacks = mock[CommCallbacks]
-    spyCommStorage = spy(new CommStorage())
+    spyCommStorage = spy[CommStorage](new CommStorage())
     mockCommRegistrar = mock[CommRegistrar]
 
     mockActorLoader = mock[ActorLoader]
@@ -79,7 +81,7 @@ class CommOpenHandlerSpec extends TestKit(
     describe("#process") {
       it("should execute open callbacks if the target exists") {
         // Mark our target as registered
-        doReturn(Some(mockCommCallbacks)).when(spyCommStorage)
+        doReturn(Some(mockCommCallbacks), Nil: _*).when(spyCommStorage)
           .getTargetCallbacks(TestTargetName)
 
         // Send a comm_open message with the test target
@@ -98,7 +100,7 @@ class CommOpenHandlerSpec extends TestKit(
 
       it("should close the comm connection if the target does not exist") {
         // Mark our target as not registered
-        doReturn(None).when(spyCommStorage).getTargetCallbacks(TestTargetName)
+        doReturn(None, Nil: _*).when(spyCommStorage).getTargetCallbacks(TestTargetName)
 
         // Send a comm_open message with the test target
         commOpenHandler ! kmBuilder
@@ -135,7 +137,7 @@ class CommOpenHandlerSpec extends TestKit(
               v1.writeMsg(MsgData.Empty)
           }
         val callbacks = (new CommCallbacks).addOpenCallback(openCallback)
-        doReturn(Some(callbacks)).when(spyCommStorage)
+        doReturn(Some(callbacks), Nil: _*).when(spyCommStorage)
           .getCommIdCallbacks(TestCommId)
 
         // Send a comm_open message

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/ExecuteRequestHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/ExecuteRequestHandlerSpec.scala
@@ -28,11 +28,13 @@ import org.apache.toree.kernel.protocol.v5.content._
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.kernel.protocol.v5Test._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.Json
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent._
@@ -43,8 +45,8 @@ class ExecuteRequestHandlerSpec extends TestKit(
     None,
     Some(org.apache.toree.Main.getClass.getClassLoader)
   )
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter {
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach {
 
   private var mockActorLoader: ActorLoader = _
   private var mockFactoryMethods: FactoryMethods = _
@@ -55,15 +57,15 @@ class ExecuteRequestHandlerSpec extends TestKit(
   private var executeRequestRelayProbe: TestProbe = _
   private var statusDispatchProbe: TestProbe = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockActorLoader = mock[ActorLoader]
     mockFactoryMethods = mock[FactoryMethods]
     mockKernel = mock[Kernel]
     mockOutputStream = mock[OutputStream]
-    doReturn(mockFactoryMethods).when(mockKernel)
+    doReturn(mockFactoryMethods, Nil: _*).when(mockKernel)
       .factory(any[KernelMessage], any[KMBuilder])
 
-    doReturn(mockOutputStream).when(mockFactoryMethods)
+    doReturn(mockOutputStream, Nil: _*).when(mockFactoryMethods)
       .newKernelOutputStream(anyString(), anyBoolean())
 
     // Add our handler and mock interpreter to the actor system

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/GenericSocketMessageHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/GenericSocketMessageHandlerSpec.scala
@@ -24,7 +24,8 @@ import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.kernel.protocol.v5Test._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Matchers, FunSpecLike}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.MaxAkkaTestTimeout
 
 class GenericSocketMessageHandlerSpec extends TestKit(
@@ -33,7 +34,7 @@ class GenericSocketMessageHandlerSpec extends TestKit(
     None,
     Some(org.apache.toree.Main.getClass.getClassLoader)
   ))
-with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   describe("GenericSocketMessageHandler( ActorLoader, SocketType )") {
     //  Create a mock ActorLoader for the Relay we are going to test
     val actorLoader: ActorLoader = mock[ActorLoader]

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/InputRequestReplyHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/InputRequestReplyHandlerSpec.scala
@@ -28,7 +28,9 @@ import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.scalatest.concurrent.Eventually
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.time.{Milliseconds, Span}
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import test.utils.MaxAkkaTestTimeout
 import org.mockito.Mockito._
 
@@ -36,8 +38,8 @@ import collection.JavaConverters._
 
 class InputRequestReplyHandlerSpec
   extends TestKit(ActorSystem("InputRequestReplyHandlerSystem", None, Some(Main.getClass.getClassLoader)))
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter with Eventually
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach with Eventually
 {
   implicit override val patienceConfig = PatienceConfig(
     timeout = scaled(Span(200, Milliseconds)),
@@ -51,12 +53,12 @@ class InputRequestReplyHandlerSpec
 
   private var inputRequestReplyHandler: ActorRef = _
 
-  before {
+  override def beforeEach(): Unit = {
     fakeSender = TestProbe()
 
     kernelMessageRelayProbe = TestProbe()
     mockActorLoader = mock[ActorLoader]
-    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path.toString))
+    doReturn(system.actorSelection(kernelMessageRelayProbe.ref.path.toString), Nil: _*)
       .when(mockActorLoader).load(SystemActorType.KernelMessageRelay)
 
     responseMap = new ConcurrentHashMap[String, ActorRef]().asScala

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/KernelInfoRequestHandlerSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/handler/KernelInfoRequestHandlerSpec.scala
@@ -23,11 +23,12 @@ import org.apache.toree.kernel.protocol.v5.content.KernelInfoReply
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.apache.toree.kernel.protocol.v5._
 import org.mockito.AdditionalMatchers.{not => mockNot}
-import org.mockito.Matchers.{eq => mockEq}
+import org.mockito.ArgumentMatchers.{eq => mockEq}
 import com.typesafe.config.ConfigFactory
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.Json
 import test.utils.MaxAkkaTestTimeout
 
@@ -42,7 +43,7 @@ class KernelInfoRequestHandlerSpec extends TestKit(
   ActorSystem("KernelInfoRequestHandlerSpec",
     ConfigFactory.parseString(KernelInfoRequestHandlerSpec.config),
     Main.getClass.getClassLoader)
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   val actorLoader: ActorLoader =  mock[ActorLoader]
   val actor = system.actorOf(Props(classOf[KernelInfoRequestHandler], actorLoader, LanguageInfo("test", "1.0.0", Some(".test"))))
 

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActorSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/interpreter/tasks/ExecuteRequestTaskActorSpec.scala
@@ -25,10 +25,11 @@ import com.typesafe.config.ConfigFactory
 import org.apache.toree.interpreter._
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
-import org.mockito.Matchers.{anyBoolean, anyString, anyObject}
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.MaxAkkaTestTimeout
 
 object ExecuteRequestTaskActorSpec {
@@ -44,14 +45,14 @@ class ExecuteRequestTaskActorSpec extends TestKit(
     ConfigFactory.parseString(ExecuteRequestTaskActorSpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   )
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
 {
   describe("ExecuteRequestTaskActor") {
     describe("#receive") {
       it("should return an ExecuteReplyOk if the interpreter returns success") {
         val mockInterpreter = mock[Interpreter]
-        doReturn((Results.Success, Left(Map()))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean(), anyObject())
+        doReturn((Results.Success, Left(Map())), Nil: _*).when(mockInterpreter)
+          .interpret(anyString(), anyBoolean(), any())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -76,8 +77,8 @@ class ExecuteRequestTaskActorSpec extends TestKit(
 
       it("should return an ExecuteReplyAbort if the interpreter returns aborted") {
         val mockInterpreter = mock[Interpreter]
-        doReturn((Results.Aborted, Right(mock[ExecuteAborted]))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean(), anyObject())
+        doReturn((Results.Aborted, Right(mock[ExecuteAborted])), Nil: _*).when(mockInterpreter)
+          .interpret(anyString(), anyBoolean(), any())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -102,8 +103,8 @@ class ExecuteRequestTaskActorSpec extends TestKit(
 
       it("should return an ExecuteReplyError if the interpreter returns error") {
         val mockInterpreter = mock[Interpreter]
-        doReturn((Results.Error, Right(mock[ExecuteError]))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean(), anyObject())
+        doReturn((Results.Error, Right(mock[ExecuteError])), Nil: _*).when(mockInterpreter)
+          .interpret(anyString(), anyBoolean(), any())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -128,8 +129,8 @@ class ExecuteRequestTaskActorSpec extends TestKit(
 
       it("should return ExecuteReplyError if interpreter returns incomplete") {
         val mockInterpreter = mock[Interpreter]
-        doReturn((Results.Incomplete, Right(""))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean(), anyObject())
+        doReturn((Results.Incomplete, Right("")), Nil: _*).when(mockInterpreter)
+          .interpret(anyString(), anyBoolean(), any())
 
         val executeRequestTask =
           system.actorOf(Props(
@@ -154,8 +155,8 @@ class ExecuteRequestTaskActorSpec extends TestKit(
 
       it("should return an ExecuteReplyOk when receiving empty code.") {
         val mockInterpreter = mock[Interpreter]
-        doReturn((Results.Incomplete, Right(""))).when(mockInterpreter)
-          .interpret(anyString(), anyBoolean(), anyObject())
+        doReturn((Results.Incomplete, Right("")), Nil: _*).when(mockInterpreter)
+          .interpret(anyString(), anyBoolean(), any())
 
         val executeRequestTask =
           system.actorOf(Props(

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/ActorLoaderSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/ActorLoaderSpec.scala
@@ -21,7 +21,8 @@ import akka.actor.{ActorSystem, Props}
 import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import org.apache.toree.kernel.protocol.v5.{MessageType, SocketType}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.TestProbeProxyActor
 import test.utils.MaxAkkaTestTimeout
 
@@ -31,7 +32,7 @@ class ActorLoaderSpec extends TestKit(
     None,
     Some(org.apache.toree.Main.getClass.getClassLoader)
   ))
-with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   describe("ActorLoader"){
     describe("#load( MessageType )"){
       it("should load an ActorSelection that has been loaded into the system"){

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/SimpleActorLoaderSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/SimpleActorLoaderSpec.scala
@@ -20,7 +20,8 @@ package org.apache.toree.kernel.protocol.v5.kernel
 import akka.actor.{ActorSelection, ActorSystem, Props}
 import akka.testkit.{TestKit, TestProbe}
 import org.apache.toree.kernel.protocol.v5.MessageType
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.TestProbeProxyActor
 import test.utils.MaxAkkaTestTimeout
 
@@ -31,7 +32,7 @@ class SimpleActorLoaderSpec extends TestKit(
     Some(org.apache.toree.Main.getClass.getClassLoader)
   )
 )
-  with FunSpecLike with Matchers
+  with AnyFunSpecLike with Matchers
 {
   describe("SimpleActorLoader") {
     //val system = ActorSystem("SimpleActorLoaderSystem")

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/UtilitiesSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/UtilitiesSpec.scala
@@ -20,12 +20,13 @@ package org.apache.toree.kernel.protocol.v5.kernel
 import akka.util.ByteString
 import org.apache.toree.communication.ZMQMessage
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * Refactored from old KernelMessageSpec.
  */
-class UtilitiesSpec extends FunSpec with Matchers {
+class UtilitiesSpec extends AnyFunSpec with Matchers {
   val header: Header = Header(
     "<UUID>", "<STRING>", "<UUID>", "<STRING>", "<FLOAT>"
   )

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/HeartbeatSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/HeartbeatSpec.scala
@@ -22,10 +22,11 @@ import akka.testkit.{ImplicitSender, TestKit, TestProbe}
 import akka.util.ByteString
 import org.apache.toree.communication.ZMQMessage
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.MaxAkkaTestTimeout
 
 object HeartbeatSpec {
@@ -41,7 +42,7 @@ class HeartbeatSpec extends TestKit(
     ConfigFactory.parseString(HeartbeatSpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   ))
-with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   val SomeMessage: String = "some message"
   val SomeZMQMessage: ZMQMessage = ZMQMessage(ByteString(SomeMessage.getBytes))
 

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/IOPubSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/IOPubSpec.scala
@@ -24,10 +24,11 @@ import org.apache.toree.kernel.protocol.v5.kernel.Utilities
 import org.apache.toree.kernel.protocol.v5Test._
 import Utilities._
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.MaxAkkaTestTimeout
 
 object IOPubSpec {
@@ -42,7 +43,7 @@ class IOPubSpec extends TestKit(
     ConfigFactory.parseString(IOPubSpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   ))
-with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
 
   describe("IOPubActor") {
     val socketFactory = mock[SocketFactory]

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/ShellSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/ShellSpec.scala
@@ -28,10 +28,11 @@ import org.apache.toree.kernel.protocol.v5.kernel.{ActorLoader, Utilities}
 import org.apache.toree.kernel.protocol.v5Test._
 import Utilities._
 import com.typesafe.config.ConfigFactory
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.MaxAkkaTestTimeout
 
 object ShellSpec {
@@ -47,7 +48,7 @@ class ShellSpec extends TestKit(
     ConfigFactory.parseString(ShellSpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   ))
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
 
   describe("Shell") {
     val socketFactory = mock[SocketFactory]

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/SocketConfigSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/SocketConfigSpec.scala
@@ -18,12 +18,13 @@
 package org.apache.toree.kernel.protocol.v5.kernel.socket
 
 import com.typesafe.config.ConfigFactory
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.slf4j.LoggerFactory
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json.{JsPath, JsValue, Json}
 
-class SocketConfigSpec extends FunSpec with Matchers {
+class SocketConfigSpec extends AnyFunSpec with Matchers {
   val logger = LoggerFactory.getLogger("jt4")
   //logger.error("WOOT!")
 

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/SocketConnectionSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/SocketConnectionSpec.scala
@@ -17,9 +17,10 @@
 
 package org.apache.toree.kernel.protocol.v5.kernel.socket
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SocketConnectionSpec extends FunSpec with Matchers {
+class SocketConnectionSpec extends AnyFunSpec with Matchers {
   describe("SocketConnection"){
    describe("#toString"){
    	it("should properly format connection string"){

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/SocketFactorySpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/SocketFactorySpec.scala
@@ -17,9 +17,10 @@
 
 package org.apache.toree.kernel.protocol.v5.kernel.socket
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class SocketFactorySpec extends FunSpec with Matchers {
+class SocketFactorySpec extends AnyFunSpec with Matchers {
   describe("SocketFactory"){
     describe("HeartbeatConnection"){
     	it("should be composed of transport ip and heartbeat port"){

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/StdinSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/kernel/socket/StdinSpec.scala
@@ -29,9 +29,10 @@ import org.apache.toree.kernel.protocol.v5.{KernelMessage, SystemActorType}
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import com.typesafe.config.ConfigFactory
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Matchers, FunSpecLike}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import test.utils.MaxAkkaTestTimeout
 
 object StdinSpec {
@@ -45,7 +46,7 @@ class StdinSpec extends TestKit(ActorSystem(
   "StdinActorSpec",
   ConfigFactory.parseString(StdinSpec.config),
   org.apache.toree.Main.getClass.getClassLoader
-)) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar {
+)) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar {
   describe("Stdin") {
     val socketFactory = mock[SocketFactory]
     val actorLoader = mock[ActorLoader]

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/magic/MagicParserSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/magic/MagicParserSpec.scala
@@ -19,11 +19,12 @@ package org.apache.toree.kernel.protocol.v5.magic
 
 import org.apache.toree.magic.{CellMagic, Magic, MagicManager}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
-class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
+class MagicParserSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("#parse") {
     it("should call parseCell if the code is a cell magic invocation") {
       val codeBlob =
@@ -32,14 +33,14 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
           |foo
           |bean
         """.stripMargin
-      val parser = spy(new MagicParser(mock[MagicManager]))
+      val parser = spy[MagicParser](new MagicParser(mock[MagicManager]))
       parser.parse(codeBlob)
       verify(parser).parseCell(codeBlob.trim)
     }
 
     it("should call parseLines if the code is not a cell magic") {
       val codeBlob = """%magic foo bean"""
-      val parser = spy(new MagicParser(mock[MagicManager]))
+      val parser = spy[MagicParser](new MagicParser(mock[MagicManager]))
       parser.parse(codeBlob)
       verify(parser).parseLines(codeBlob.trim)
     }
@@ -49,8 +50,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should substitute the magic code for kernel code when magic is valid") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(true).when(magicManager).isCellMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(true, Nil: _*).when(magicManager).isCellMagic(mockMagic)
 
       val magicName = "magic"
       val args = "foo\nbean\nbar"
@@ -58,7 +59,7 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
         s"""%%$magicName
            |$args
          """.stripMargin
-      val parser = spy(new MagicParser(magicManager))
+      val parser = spy[MagicParser](new MagicParser(magicManager))
       val result = parser.parseCell(codeBlob)
 
       verify(parser).substitute(magicName, args)
@@ -68,8 +69,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return an error if the magic invocation is invalid") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(false).when(magicManager).isCellMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(false, Nil: _*).when(magicManager).isCellMagic(mockMagic)
 
       val magicName = "magic"
       val args = "foo\nbean\nbar"
@@ -77,7 +78,7 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
         s"""%%$magicName
            |$args
          """.stripMargin
-      val parser = spy(new MagicParser(magicManager))
+      val parser = spy[MagicParser](new MagicParser(magicManager))
       val result = parser.parseCell(codeBlob)
 
       verify(parser, times(0)).substitute(anyString(), anyString())
@@ -87,14 +88,14 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return original code if code contains no magic invocations") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(false).when(magicManager).isCellMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(false, Nil: _*).when(magicManager).isCellMagic(mockMagic)
 
       val codeBlob =
         s"""val x = 3
            |println(x + 2)
          """.stripMargin
-      val parser = spy(new MagicParser(magicManager))
+      val parser = spy[MagicParser](new MagicParser(magicManager))
       val result = parser.parseCell(codeBlob)
 
       verify(parser, times(0)).substitute(anyString(), anyString())
@@ -108,14 +109,14 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
       "when there are no invalid magic invocations") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(true).when(magicManager).isLineMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(true, Nil: _*).when(magicManager).isLineMagic(mockMagic)
 
       val codeBlob =
         s"""val x = 3
            |%lineMagic
          """.stripMargin
-      val parser = spy(new MagicParser(magicManager))
+      val parser = spy[MagicParser](new MagicParser(magicManager))
       val result = parser.parseLines(codeBlob)
 
       verify(parser, times(2)).substituteLine(anyString())
@@ -125,14 +126,14 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return an error when there are invalid magic invocations") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(false).when(magicManager).isLineMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(false, Nil: _*).when(magicManager).isLineMagic(mockMagic)
 
       val codeBlob =
         s"""val x = 3
            |%lineMagic
          """.stripMargin
-      val parser = spy(new MagicParser(magicManager))
+      val parser = spy[MagicParser](new MagicParser(magicManager))
       val result = parser.parseLines(codeBlob)
 
       verify(parser, times(0)).substituteLine(anyString())
@@ -142,14 +143,14 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return original code when there are no magic invocations") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(false).when(magicManager).isLineMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(false, Nil: _*).when(magicManager).isLineMagic(mockMagic)
 
       val codeBlob =
         s"""val x = 3
            |val y = x + 2
          """.stripMargin
-      val parser = spy(new MagicParser(magicManager))
+      val parser = spy[MagicParser](new MagicParser(magicManager))
       val result = parser.parseLines(codeBlob.trim)
 
       result.isLeft should be(true)
@@ -188,8 +189,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
       val magicName = "magic"
       val args = "-v foo bar"
       val codeLine = s"""%$magicName $args"""
-      val parser = spy(new MagicParser(mock[MagicManager]))
-      doReturn(true).when(parser).isValidLineMagic(anyString())
+      val parser = spy[MagicParser](new MagicParser(mock[MagicManager]))
+      doReturn(true, Nil: _*).when(parser).isValidLineMagic(anyString())
       parser.substituteLine(codeLine)
       verify(parser).substitute(magicName, args)
     }
@@ -197,8 +198,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return original line of code when it's not a valid +" +
       "magic invocation") {
       val codeLine = """val x = 3"""
-      val parser = spy(new MagicParser(mock[MagicManager]))
-      doReturn(false).when(parser).isValidLineMagic(anyString())
+      val parser = spy[MagicParser](new MagicParser(mock[MagicManager]))
+      doReturn(false, Nil: _*).when(parser).isValidLineMagic(anyString())
       parser.substituteLine(codeLine) should be(codeLine)
     }
   }
@@ -225,8 +226,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
           |%$magicOne bar baz
           |%$magicTwo quo bean
         """.stripMargin
-      val parser = spy(new MagicParser(mock[MagicManager]))
-      doReturn(false).when(parser).isValidLineMagic(anyString())
+      val parser = spy[MagicParser](new MagicParser(mock[MagicManager]))
+      doReturn(false, Nil: _*).when(parser).isValidLineMagic(anyString())
 
       parser.parseOutInvalidMagics(codeBlob) should be(List(magicOne, magicTwo))
     }
@@ -239,8 +240,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
           |%$magicOne bar baz
           |%$magicTwo quo bean
         """.stripMargin
-      val parser = spy(new MagicParser(mock[MagicManager]))
-      doReturn(true).when(parser).isValidLineMagic(anyString())
+      val parser = spy[MagicParser](new MagicParser(mock[MagicManager]))
+      doReturn(true, Nil: _*).when(parser).isValidLineMagic(anyString())
 
       parser.parseOutInvalidMagics(codeBlob) should be(Nil)
     }
@@ -250,8 +251,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return true if the line magic invocation is valid") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(true).when(magicManager).isLineMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(true, Nil: _*).when(magicManager).isLineMagic(mockMagic)
 
       val parser = new MagicParser(magicManager)
       parser.isValidLineMagic("%foobar baz") should be(true)
@@ -260,8 +261,8 @@ class MagicParserSpec extends FunSpec with Matchers with MockitoSugar {
     it("should return false if the line magic invocation is not valid") {
       val magicManager = mock[MagicManager]
       val mockMagic = mock[Magic]
-      doReturn(mockMagic).when(magicManager).findMagic(anyString())
-      doReturn(false).when(magicManager).isLineMagic(mockMagic)
+      doReturn(mockMagic, Nil: _*).when(magicManager).findMagic(anyString())
+      doReturn(false, Nil: _*).when(magicManager).isLineMagic(mockMagic)
 
       val parser = new MagicParser(magicManager)
       parser.isValidLineMagic("%foobar baz") should be(false)

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/relay/ExecuteRequestRelaySpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/relay/ExecuteRequestRelaySpec.scala
@@ -31,7 +31,9 @@ import org.apache.toree.plugins.PluginManager
 import org.apache.toree.plugins.dependencies.DependencyManager
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
 import test.utils.MaxAkkaTestTimeout
 import scala.concurrent.duration.Duration
 
@@ -48,18 +50,18 @@ class ExecuteRequestRelaySpec extends TestKit(
     ConfigFactory.parseString(ExecuteRequestRelaySpec.config),
     org.apache.toree.Main.getClass.getClassLoader
   )
-) with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter
+) with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   var mockActorLoader: ActorLoader      = _
   var interpreterActorProbe: TestProbe  = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockActorLoader = mock[ActorLoader]
     interpreterActorProbe = new TestProbe(system)
     val mockInterpreterActorSelection =
       system.actorSelection(interpreterActorProbe.ref.path.toString)
-    doReturn(mockInterpreterActorSelection).when(mockActorLoader)
+    doReturn(mockInterpreterActorSelection, Nil: _*).when(mockActorLoader)
       .load(SystemActorType.Interpreter)
   }
 
@@ -71,10 +73,10 @@ class ExecuteRequestRelaySpec extends TestKit(
 
         val mockPluginManager = mock[PluginManager]
         val mockDependencyManager = mock[DependencyManager]
-        doReturn(mockDependencyManager).when(mockPluginManager).dependencyManager
+        doReturn(mockDependencyManager, Nil: _*).when(mockPluginManager).dependencyManager
 
         val mockMagicParser = mock[MagicParser]
-        doReturn(Left(executeRequest.code))
+        doReturn(Left(executeRequest.code), Nil: _*)
           .when(mockMagicParser).parse(executeRequest.code)
 
         val executeRequestRelay = system.actorOf(Props(
@@ -108,10 +110,10 @@ class ExecuteRequestRelaySpec extends TestKit(
 
         val mockPluginManager = mock[PluginManager]
         val mockDependencyManager = mock[DependencyManager]
-        doReturn(mockDependencyManager).when(mockPluginManager).dependencyManager
+        doReturn(mockDependencyManager, Nil: _*).when(mockPluginManager).dependencyManager
 
         val mockMagicParser = mock[MagicParser]
-        doReturn(Left(executeRequest.code))
+        doReturn(Left(executeRequest.code), Nil: _*)
           .when(mockMagicParser).parse(executeRequest.code)
 
         val executeRequestRelay = system.actorOf(Props(
@@ -151,10 +153,10 @@ class ExecuteRequestRelaySpec extends TestKit(
 
         val mockPluginManager = mock[PluginManager]
         val mockDependencyManager = mock[DependencyManager]
-        doReturn(mockDependencyManager).when(mockPluginManager).dependencyManager
+        doReturn(mockDependencyManager, Nil: _*).when(mockPluginManager).dependencyManager
 
         val mockMagicParser = mock[MagicParser]
-        doReturn(Left(executeRequest.code))
+        doReturn(Left(executeRequest.code), Nil: _*)
           .when(mockMagicParser).parse(executeRequest.code)
 
         val executeRequestRelay = system.actorOf(Props(

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/relay/KernelMessageRelaySpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/relay/KernelMessageRelaySpec.scala
@@ -27,9 +27,10 @@ import Utilities._
 import org.mockito.Mockito._
 import org.scalatest.concurrent.{PatienceConfiguration, ScalaFutures}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.time.{Millis, Seconds, Span}
-import org.scalatest.{BeforeAndAfter, FunSpecLike, Matchers}
-import org.mockito.Matchers.{eq => mockEq}
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.BeforeAndAfterEach
+import org.mockito.ArgumentMatchers.{eq => mockEq}
 import org.mockito.AdditionalMatchers.{not => mockNot}
 import org.apache.toree.kernel.protocol.v5.KernelMessage
 import scala.concurrent._
@@ -45,8 +46,8 @@ class KernelMessageRelaySpec extends TestKit(
     Some(org.apache.toree.Main.getClass.getClassLoader)
   )
 )
-  with ImplicitSender with FunSpecLike with Matchers with MockitoSugar
-  with BeforeAndAfter with ScalaFutures {
+  with ImplicitSender with AnyFunSpecLike with Matchers with MockitoSugar
+  with BeforeAndAfterEach with ScalaFutures {
   private val IncomingMessageType = MessageType.Incoming.CompleteRequest.toString
   private val OutgoingMessageType = MessageType.Outgoing.CompleteReply.toString
 
@@ -70,7 +71,7 @@ class KernelMessageRelaySpec extends TestKit(
   private var relayWithoutSignatureManager: ActorRef = _
   private var relayWithSignatureManager: ActorRef = _
 
-  before {
+  override def beforeEach(): Unit = {
     // Create a mock ActorLoader for the Relay we are going to test
     actorLoader = mock[ActorLoader]
 

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/stream/KernelInputStreamSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/stream/KernelInputStreamSpec.scala
@@ -17,7 +17,7 @@
 
 package org.apache.toree.kernel.protocol.v5.stream
 
-import akka.actor.{ActorRef, Actor, ActorSystem}
+import akka.actor.{Actor, ActorRef, ActorSystem}
 import akka.testkit.{TestActorRef, TestKit, TestProbe}
 import org.apache.toree.Main
 import org.apache.toree.kernel.protocol.v5._
@@ -25,13 +25,15 @@ import org.apache.toree.kernel.protocol.v5.content.InputRequest
 import org.apache.toree.kernel.protocol.v5.kernel.ActorLoader
 import org.mockito.Mockito._
 import org.scalatest._
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.libs.json.Json
 import test.utils._
 
 class KernelInputStreamSpec
   extends TestKit(ActorSystem("KernelInputStreamActorSystem", None, Some(Main.getClass.getClassLoader)))
-  with FunSpecLike with Matchers with GivenWhenThen with BeforeAndAfter
+  with AnyFunSpecLike with Matchers with GivenWhenThen with BeforeAndAfterEach
   with MockitoSugar
 {
 
@@ -43,7 +45,7 @@ class KernelInputStreamSpec
 
   private val TestReplyString = "some reply"
 
-  before {
+  override def beforeEach(): Unit = {
     mockActorLoader = mock[ActorLoader]
     mockKMBuilder = KMBuilder() // No need to really mock this
 
@@ -63,7 +65,7 @@ class KernelInputStreamSpec
 
     // Add the actor that routes to our test probe and responds with a fake
     // set of data
-    doReturn(system.actorSelection(fakeInputOutputHandlerActor.path.toString))
+    doReturn(system.actorSelection(fakeInputOutputHandlerActor.path.toString), Nil: _*)
       .when(mockActorLoader).load(MessageType.Incoming.InputReply)
     // Allow time for the actors to start. This avoids read() hanging forever
     // when running tests in gradle.

--- a/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/stream/KernelOuputStreamSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/kernel/protocol/v5/stream/KernelOuputStreamSpec.scala
@@ -18,7 +18,6 @@
 package org.apache.toree.kernel.protocol.v5.stream
 
 import java.util.UUID
-
 import akka.actor.{ActorSelection, ActorSystem}
 import akka.testkit.{TestKit, TestProbe}
 import org.apache.toree.Main
@@ -30,11 +29,13 @@ import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest._
 import play.api.libs.json._
 import org.apache.toree.kernel.protocol.v5.content.StreamContent
+import org.scalatest.funspec.AnyFunSpecLike
+import org.scalatest.matchers.should.Matchers
 import test.utils.MaxAkkaTestTimeout
 
 class KernelOuputStreamSpec
   extends TestKit(ActorSystem("KernelOutputStreamActorSystem", None, Some(Main.getClass.getClassLoader)))
-  with FunSpecLike with Matchers with GivenWhenThen with BeforeAndAfter
+  with AnyFunSpecLike with Matchers with GivenWhenThen with BeforeAndAfterEach
   with MockitoSugar
 {
 
@@ -85,7 +86,7 @@ class KernelOuputStreamSpec
     def teardown(): Unit = super.stop()
   }
 
-  before {
+  override def beforeEach(): Unit = {
     // Create a mock ActorLoader for the KernelOutputStream we are testing
     mockActorLoader = mock[ActorLoader]
 
@@ -96,11 +97,11 @@ class KernelOuputStreamSpec
     kernelOutputRelayProbe = TestProbe()
     val kernelOutputRelaySelection: ActorSelection =
       system.actorSelection(kernelOutputRelayProbe.ref.path.toString)
-    doReturn(kernelOutputRelaySelection)
+    doReturn(kernelOutputRelaySelection, Nil: _*)
       .when(mockActorLoader).load(SystemActorType.KernelMessageRelay)
   }
 
-  after {
+  override def afterEach(): Unit = {
     mockScheduledTaskManager.teardown()
   }
 

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/AddDepsSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/AddDepsSpec.scala
@@ -23,13 +23,15 @@ import org.apache.toree.dependencies.{Credentials, DependencyDownloader}
 import org.apache.toree.utils.ArgumentParsingSupport
 import org.apache.toree.kernel.api.KernelLike
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, GivenWhenThen, Matchers}
+import org.scalatest.GivenWhenThen
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.apache.toree.magic._
 import org.apache.toree.magic.dependencies._
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
+class AddDepsSpec extends AnyFunSpec with Matchers with MockitoSugar
   with GivenWhenThen
 {
   describe("AddDeps"){
@@ -70,7 +72,7 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
 
       it("should set the retrievals transitive to true if provided") {
         val mockDependencyDownloader = mock[DependencyDownloader]
-        doReturn(Nil).when(mockDependencyDownloader).retrieve(
+        doReturn(Nil, Nil: _*).when(mockDependencyDownloader).retrieve(
           anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
           anyBoolean(), any[Seq[(URL, Option[Credentials])]], anyBoolean(), anyBoolean(),
           any[Option[String]], any[Option[String]], any[Option[String]], any[Set[(String,String)]]
@@ -97,7 +99,7 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
 
       it("should set the retrieval's transitive to false if not provided") {
         val mockDependencyDownloader = mock[DependencyDownloader]
-        doReturn(Nil).when(mockDependencyDownloader).retrieve(
+        doReturn(Nil, Nil: _*).when(mockDependencyDownloader).retrieve(
           anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
           anyBoolean(), any[Seq[(URL, Option[Credentials])]], anyBoolean(), anyBoolean(),
           any[Option[String]], any[Option[String]], any[Option[String]], any[Set[(String,String)]]
@@ -124,7 +126,7 @@ class AddDepsSpec extends FunSpec with Matchers with MockitoSugar
 
       it("should add retrieved artifacts to the kernel") {
         val mockDependencyDownloader = mock[DependencyDownloader]
-        doReturn(Nil).when(mockDependencyDownloader).retrieve(
+        doReturn(Nil, Nil: _*).when(mockDependencyDownloader).retrieve(
           anyString(), anyString(), anyString(), anyBoolean(), anyBoolean(),
           anyBoolean(), any[Seq[(URL, Option[Credentials])]], anyBoolean(), anyBoolean(),
           any[Option[String]], any[Option[String]], any[Option[String]], any[Set[(String,String)]]

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/AddJarSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/AddJarSpec.scala
@@ -27,12 +27,13 @@ import com.typesafe.config.ConfigFactory
 import org.apache.spark.SparkContext
 import org.apache.toree.kernel.api.KernelLike
 import org.apache.toree.plugins.PluginManager
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
-class AddJarSpec extends FunSpec with Matchers with MockitoSugar {
+class AddJarSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("AddJar"){
     describe("#execute") {
       it("should call addJar on the provided kernel") {

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/BuiltinLoaderSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/BuiltinLoaderSpec.scala
@@ -18,9 +18,10 @@
 package org.apache.toree.magic.builtin
 
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class BuiltinLoaderSpec extends FunSpec with Matchers with MockitoSugar {
+class BuiltinLoaderSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("BuiltinLoader") {
     describe("#getClasses") {
       it("should return classes in a package") {

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/DataFrameSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/DataFrameSpec.scala
@@ -21,14 +21,16 @@ import org.apache.toree.interpreter._
 import org.apache.toree.kernel.protocol.v5.MIMEType
 import org.apache.toree.magic.dependencies.IncludeKernelInterpreter
 import org.apache.toree.utils.DataFrameConverter
-import org.mockito.Matchers.{anyString, eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Success
 
-class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter {
+class DataFrameSpec extends AnyFunSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
 
   def createMocks = {
     val interpreter = mock[Interpreter]
@@ -59,7 +61,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val (magic, interpreter, _) = createMocks
         val mockExecuteError = mock[ExecuteError]
         val mockError = "error"
-        doReturn(mockError).when(mockExecuteError).value
+        doReturn(mockError, Nil: _*).when(mockExecuteError).value
         val message: Either[ExecuteOutput, ExecuteFailure] = Right(mockExecuteError)
         val code = "code"
         when(interpreter.interpret(code)).thenReturn((Results.Error, message))
@@ -75,7 +77,7 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val (magic, interpreter, _) = createMocks
         val mockExecuteError = mock[ExecuteError]
         val mockError = "error"
-        doReturn(mockError).when(mockExecuteError).value
+        doReturn(mockError, Nil: _*).when(mockExecuteError).value
         val message: Either[ExecuteOutput, ExecuteFailure] = Right(mockExecuteError )
         val code = "code"
         when(interpreter.interpret(code)).thenReturn((Results.Error, message))
@@ -105,9 +107,9 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
                              |${variableName}
                   """.stripMargin
         when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
-        doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
-        doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
-        doReturn(Success(outputText)).when(converter).convert(
+        doReturn(Some(variableName), Nil: _*).when(interpreter).lastExecutionVariableName
+        doReturn(Some(mockDataFrame), Nil: _*).when(interpreter).read(variableName)
+        doReturn(Success(outputText), Nil: _*).when(converter).convert(
           mockDataFrame,"json", 10
         )
         val output = magic.execute(executeCode).asMap
@@ -125,9 +127,9 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
                              |${variableName}
                   """.stripMargin
         when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
-        doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
-        doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
-        doReturn(Success(outputText)).when(converter).convert(
+        doReturn(Some(variableName), Nil: _*).when(interpreter).lastExecutionVariableName
+        doReturn(Some(mockDataFrame), Nil: _*).when(interpreter).read(variableName)
+        doReturn(Success(outputText), Nil: _*).when(converter).convert(
           mockDataFrame,"html", 10
         )
         val output = magic.execute(executeCode).asMap
@@ -145,9 +147,9 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
                              |${variableName}
                   """.stripMargin
         when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
-        doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
-        doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
-        doReturn(Success(outputText)).when(converter).convert(
+        doReturn(Some(variableName), Nil: _*).when(interpreter).lastExecutionVariableName
+        doReturn(Some(mockDataFrame), Nil: _*).when(interpreter).read(variableName)
+        doReturn(Success(outputText), Nil: _*).when(converter).convert(
           mockDataFrame,"csv", 10
         )
         val output = magic.execute(executeCode).asMap
@@ -165,9 +167,9 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
                              |${variableName}
                   """.stripMargin
         when(interpreter.interpret(variableName)).thenReturn((Results.Success, message))
-        doReturn(Some(variableName)).when(interpreter).lastExecutionVariableName
-        doReturn(Some(mockDataFrame)).when(interpreter).read(variableName)
-        doReturn(Success(outputText)).when(converter).convert(
+        doReturn(Some(variableName), Nil: _*).when(interpreter).lastExecutionVariableName
+        doReturn(Some(mockDataFrame), Nil: _*).when(interpreter).read(variableName)
+        doReturn(Success(outputText), Nil: _*).when(converter).convert(
           mockDataFrame,"html", 3
         )
         magic.execute(executeCode)
@@ -181,8 +183,8 @@ class DataFrameSpec extends FunSpec with Matchers with MockitoSugar with BeforeA
         val mockDataFrame = mock[org.apache.spark.sql.DataFrame]
         val code = "variable"
         when(interpreter.interpret(code)).thenReturn((Results.Success, message))
-        doReturn(Some(code)).when(interpreter).lastExecutionVariableName
-        doReturn(Some(mockDataFrame)).when(interpreter).read(code)
+        doReturn(Some(code), Nil: _*).when(interpreter).lastExecutionVariableName
+        doReturn(Some(mockDataFrame), Nil: _*).when(interpreter).read(code)
         doThrow(new RuntimeException()).when(converter).convert(
           mockDataFrame,"html", 10
         )

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/HtmlSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/HtmlSpec.scala
@@ -20,9 +20,10 @@ package org.apache.toree.magic.builtin
 import org.apache.toree.kernel.protocol.v5.MIMEType
 import org.apache.toree.magic.CellMagicOutput
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class HtmlSpec extends FunSpec with Matchers with MockitoSugar {
+class HtmlSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("Html"){
     describe("#execute") {
       it("should return the entire cell's contents with the MIME type of " +

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/JavaScriptSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/JavaScriptSpec.scala
@@ -18,11 +18,12 @@
 package org.apache.toree.magic.builtin
 
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.apache.toree.magic.CellMagicOutput
 import org.apache.toree.kernel.protocol.v5.MIMEType
 
-class JavaScriptSpec extends FunSpec with Matchers with MockitoSugar {
+class JavaScriptSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("JavaScript"){
     describe("#execute") {
       it("should return the entire cell's contents with the MIME type of text/javascript") {

--- a/kernel/src/test/scala/org/apache/toree/magic/builtin/LSMagicSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/magic/builtin/LSMagicSpec.scala
@@ -24,11 +24,12 @@ import org.apache.toree.interpreter.Interpreter
 import org.apache.toree.magic.dependencies.{IncludeOutputStream, IncludeInterpreter}
 import org.apache.toree.magic.{CellMagic, LineMagic}
 import org.apache.spark.SparkContext
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import org.mockito.Mockito._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 
 class TestLSMagic(sc: SparkContext, intp: Interpreter, os: OutputStream)
   extends LSMagic
@@ -39,12 +40,12 @@ class TestLSMagic(sc: SparkContext, intp: Interpreter, os: OutputStream)
     override val outputStream: OutputStream = os
   }
 
-class LSMagicSpec extends FunSpec with Matchers with MockitoSugar {
+class LSMagicSpec extends AnyFunSpec with Matchers with MockitoSugar {
   describe("LSMagic") {
 
     describe("#execute") {
       it("should call println with a magics message") {
-        val lsm = spy(new TestLSMagic(
+        val lsm = spy[TestLSMagic](new TestLSMagic(
           mock[SparkContext], mock[Interpreter], mock[OutputStream])
         )
         val classList = new BuiltinLoader().loadClasses()

--- a/kernel/src/test/scala/org/apache/toree/utils/DataFrameConverterSpec.scala
+++ b/kernel/src/test/scala/org/apache/toree/utils/DataFrameConverterSpec.scala
@@ -21,13 +21,15 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsArray, JsDefined, JsString, JsValue, Json}
 import test.utils.SparkContextProvider
 
 import scala.collection.mutable
 
-class DataFrameConverterSpec extends FunSpec with MockitoSugar with Matchers with BeforeAndAfterAll {
+class DataFrameConverterSpec extends AnyFunSpec with MockitoSugar with Matchers with BeforeAndAfterAll {
 
   lazy val spark = SparkContextProvider.sparkContext
 
@@ -42,9 +44,9 @@ class DataFrameConverterSpec extends FunSpec with MockitoSugar with Matchers wit
   val mockStruct = mock[StructType]
   val columns = Array("foo", "bar")
 
-  doReturn(mockStruct).when(mockDataFrame).schema
-  doReturn(columns).when(mockStruct).fieldNames
-  doReturn(mockRdd).when(mockDataFrame).rdd
+  doReturn(mockStruct, Nil: _*).when(mockDataFrame).schema
+  doReturn(columns, Nil: _*).when(mockStruct).fieldNames
+  doReturn(mockRdd, Nil: _*).when(mockDataFrame).rdd
 
   describe("DataFrameConverter") {
     describe("#convert") {

--- a/plugins/src/test/scala/integration/PluginManagerSpecForIntegration.scala
+++ b/plugins/src/test/scala/integration/PluginManagerSpecForIntegration.scala
@@ -18,9 +18,11 @@ package integration
 
 import org.apache.toree.plugins.{PluginManager, Plugin}
 import org.apache.toree.plugins.annotations.Init
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class PluginManagerSpecForIntegration extends FunSpec with Matchers
+class PluginManagerSpecForIntegration extends AnyFunSpec with Matchers
   with OneInstancePerTest
 {
   private val pluginManager = new PluginManager

--- a/plugins/src/test/scala/org/apache/toree/plugins/ImplicitsSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/ImplicitsSpec.scala
@@ -18,9 +18,11 @@
 package org.apache.toree.plugins
 
 import org.apache.toree.plugins.dependencies.Dependency
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class ImplicitsSpec extends FunSpec with Matchers with OneInstancePerTest {
+class ImplicitsSpec extends AnyFunSpec with Matchers with OneInstancePerTest {
   describe("Implicits") {
     describe("#$dep") {
       it("should convert values to dependencies with generated names") {

--- a/plugins/src/test/scala/org/apache/toree/plugins/PluginClassLoaderSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/PluginClassLoaderSpec.scala
@@ -18,9 +18,11 @@ package org.apache.toree.plugins
 
 import java.io.File
 
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class PluginClassLoaderSpec extends FunSpec with Matchers
+class PluginClassLoaderSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest
 {
   describe("PluginClassLoader") {

--- a/plugins/src/test/scala/org/apache/toree/plugins/PluginManagerSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/PluginManagerSpec.scala
@@ -19,13 +19,15 @@ package org.apache.toree.plugins
 import java.io.File
 
 import org.apache.toree.plugins.dependencies.DependencyManager
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{FunSpec, Matchers, OneInstancePerTest}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 import test.utils._
 
-class PluginManagerSpec extends FunSpec with Matchers
+class PluginManagerSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest with MockitoSugar
 {
   private val TestPluginName = "some.plugin.class.name"
@@ -50,10 +52,10 @@ class PluginManagerSpec extends FunSpec with Matchers
         )
 
         // When returning class information
-        doReturn(classInfoList.toIterator)
+        doReturn(classInfoList.toIterator, Nil: _*)
           .when(mockPluginSearcher).search(any[File])
 
-        doReturn(classOf[TestPlugin])
+        doReturn(classOf[TestPlugin], Nil: _*)
           .when(mockPluginClassLoader).loadClass(anyString())
 
         // Perform the loading of plugins
@@ -78,10 +80,10 @@ class PluginManagerSpec extends FunSpec with Matchers
         )
 
         // When returning class information
-        doReturn(classInfoList.toIterator)
+        doReturn(classInfoList.toIterator, Nil: _*)
           .when(mockPluginSearcher).search(any[File])
 
-        doReturn(classOf[TestPlugin])
+        doReturn(classOf[TestPlugin], Nil: _*)
           .when(mockPluginClassLoader).loadClass(anyString())
 
         // Perform the loading of plugins
@@ -154,7 +156,7 @@ class PluginManagerSpec extends FunSpec with Matchers
       it("should load nothing if the plugin searcher returns empty handed") {
         val expected = Nil
 
-        doReturn(Iterator.empty).when(mockPluginSearcher).search(any[File])
+        doReturn(Iterator.empty, Nil: _*).when(mockPluginSearcher).search(any[File])
         val actual = pluginManager.loadPlugins(mock[File])
 
         actual should be (expected)
@@ -169,10 +171,10 @@ class PluginManagerSpec extends FunSpec with Matchers
         )
 
         // When returning class information
-        doReturn(classInfoList.toIterator)
+        doReturn(classInfoList.toIterator, Nil: _*)
           .when(mockPluginSearcher).search(any[File])
 
-        doReturn(classOf[TestPlugin])
+        doReturn(classOf[TestPlugin], Nil: _*)
           .when(mockPluginClassLoader).loadClass(anyString())
 
         // Perform the loading of plugins
@@ -192,10 +194,10 @@ class PluginManagerSpec extends FunSpec with Matchers
         )
 
         // When returning class information
-        doReturn(classInfoList.toIterator)
+        doReturn(classInfoList.toIterator, Nil: _*)
           .when(mockPluginSearcher).search(any[File])
 
-        doReturn(classOf[TestPlugin])
+        doReturn(classOf[TestPlugin], Nil: _*)
           .when(mockPluginClassLoader).loadClass(anyString())
 
         // Perform the loading of plugins
@@ -232,7 +234,7 @@ class PluginManagerSpec extends FunSpec with Matchers
         val dependencyManager = new DependencyManager
         dependencyManager.add(dependency)
 
-        doReturn(dependencyManager).when(mockDependencyManager)
+        doReturn(dependencyManager, Nil: _*).when(mockDependencyManager)
           .merge(dependencyManager)
 
         pluginManager.initializePlugins(Seq(testPlugin), dependencyManager)
@@ -297,7 +299,7 @@ class PluginManagerSpec extends FunSpec with Matchers
         val dependencyManager = new DependencyManager
         dependencyManager.add(dependency)
 
-        doReturn(dependencyManager).when(mockDependencyManager)
+        doReturn(dependencyManager, Nil: _*).when(mockDependencyManager)
           .merge(dependencyManager)
 
         pluginManager.destroyPlugins(Seq(testPlugin), dependencyManager)
@@ -414,7 +416,7 @@ class PluginManagerSpec extends FunSpec with Matchers
         val dm = new DependencyManager
         dm.add(TestPluginDependency(999))
 
-        doReturn(dm).when(mockDependencyManager).merge(any[DependencyManager])
+        doReturn(dm, Nil: _*).when(mockDependencyManager).merge(any[DependencyManager])
 
         val actual = pluginManager.fireEventLastResult(
           TestPlugin.DefaultEvent, dm.toSeq: _*
@@ -470,15 +472,15 @@ class PluginManagerSpec extends FunSpec with Matchers
           calledMulti += 1
         })
 
-        doReturn(dependencyManager).when(mockDependencyManager)
+        doReturn(dependencyManager, Nil: _*).when(mockDependencyManager)
           .merge(dependencyManager)
         pluginManager.fireEvent(TestPlugin.DefaultEvent, dependencyManager)
 
-        doReturn(dependencyManager).when(mockDependencyManager)
+        doReturn(dependencyManager, Nil: _*).when(mockDependencyManager)
           .merge(dependencyManager)
         pluginManager.fireEvent(TestPlugin.DefaultEvents1, dependencyManager)
 
-        doReturn(dependencyManager).when(mockDependencyManager)
+        doReturn(dependencyManager, Nil: _*).when(mockDependencyManager)
           .merge(dependencyManager)
         pluginManager.fireEvent(TestPlugin.DefaultEvents2, dependencyManager)
 

--- a/plugins/src/test/scala/org/apache/toree/plugins/PluginMethodResultSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/PluginMethodResultSpec.scala
@@ -20,12 +20,14 @@ import java.lang.reflect.Method
 
 import org.apache.toree.plugins.annotations.{Priority, Event}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
 
 import scala.util.{Failure, Success, Try}
 
-class PluginMethodResultSpec extends FunSpec with Matchers
+class PluginMethodResultSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest with MockitoSugar
 {
   private val testResult = new AnyRef

--- a/plugins/src/test/scala/org/apache/toree/plugins/PluginMethodSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/PluginMethodSpec.scala
@@ -19,9 +19,11 @@ package org.apache.toree.plugins
 
 import org.apache.toree.plugins.annotations._
 import org.apache.toree.plugins.dependencies.{DepClassNotFoundException, DepUnexpectedClassException, DepNameNotFoundException}
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class PluginMethodSpec extends FunSpec with Matchers with OneInstancePerTest {
+class PluginMethodSpec extends AnyFunSpec with Matchers with OneInstancePerTest {
   private val testThrowable = new Throwable
   private case class TestDependency(x: Int)
   private class TestPlugin extends Plugin {

--- a/plugins/src/test/scala/org/apache/toree/plugins/PluginSearcherSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/PluginSearcherSpec.scala
@@ -20,12 +20,14 @@ import java.io.File
 
 import org.clapper.classutil.{Modifier, ClassFinder}
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import org.mockito.Mockito._
 import test.utils.TestClassInfo
 
-class PluginSearcherSpec extends FunSpec with Matchers
+class PluginSearcherSpec extends AnyFunSpec with Matchers
   with OneInstancePerTest with MockitoSugar
 {
   private val mockClassFinder = mock[ClassFinder]
@@ -75,7 +77,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins directly extending the Plugin class") {
         val expected = directPluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.internal.map(_.name)
 
@@ -85,7 +87,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins directly extending the Plugin trait") {
         val expected = directAsInterfacePluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.internal.map(_.name)
 
@@ -95,7 +97,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins indirectly extending the Plugin class") {
         val expected = indirectPluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.internal.map(_.name)
 
@@ -105,7 +107,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins indirectly extending the Plugin trait") {
         val expected = indirectAsInterfacePluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.internal.map(_.name)
 
@@ -118,7 +120,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
           traitPluginClassInfo.name
         )
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.internal.map(_.name)
 
@@ -130,7 +132,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins directly extending the Plugin class") {
         val expected = directPluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.search().map(_.name).toSeq
 
@@ -140,7 +142,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins directly extending the Plugin trait") {
         val expected = directAsInterfacePluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.search().map(_.name).toSeq
 
@@ -150,7 +152,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins indirectly extending the Plugin class") {
         val expected = indirectPluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.search().map(_.name).toSeq
 
@@ -160,7 +162,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
       it("should find any plugins indirectly extending the Plugin trait") {
         val expected = indirectAsInterfacePluginClassInfo.name
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.search().map(_.name).toSeq
 
@@ -173,7 +175,7 @@ class PluginSearcherSpec extends FunSpec with Matchers
           traitPluginClassInfo.name
         )
 
-        doReturn(classInfos.toStream).when(mockClassFinder).getClasses()
+        doReturn(classInfos.toStream, Nil: _*).when(mockClassFinder).getClasses()
 
         val actual = pluginSearcher.search().map(_.name).toSeq
 

--- a/plugins/src/test/scala/org/apache/toree/plugins/PluginSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/PluginSpec.scala
@@ -21,12 +21,14 @@ import java.lang.reflect.Method
 import org.apache.toree.plugins.annotations._
 import org.apache.toree.plugins.dependencies.DependencyManager
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 import scala.reflect.runtime.universe._
 
-class PluginSpec extends FunSpec with Matchers with OneInstancePerTest with MockitoSugar {
+class PluginSpec extends AnyFunSpec with Matchers with OneInstancePerTest with MockitoSugar {
   private val mockPluginManager = mock[PluginManager]
   private val testPlugin = {
     val plugin = new TestPlugin
@@ -261,7 +263,7 @@ class PluginSpec extends FunSpec with Matchers with OneInstancePerTest with Mock
         val value = new AnyRef
         val mockDependencyManager = mock[DependencyManager]
         doNothing().when(mockDependencyManager).add(anyString(), mockEq(value))(any[TypeTag[AnyRef]])
-        doReturn(mockDependencyManager).when(mockPluginManager).dependencyManager
+        doReturn(mockDependencyManager, Nil: _*).when(mockPluginManager).dependencyManager
 
         registerPlugin.register(value)
       }
@@ -273,7 +275,7 @@ class PluginSpec extends FunSpec with Matchers with OneInstancePerTest with Mock
         val value = new AnyRef
         val mockDependencyManager = mock[DependencyManager]
         doNothing().when(mockDependencyManager).add(mockEq(name), mockEq(value))(any[TypeTag[AnyRef]])
-        doReturn(mockDependencyManager).when(mockPluginManager).dependencyManager
+        doReturn(mockDependencyManager, Nil: _*).when(mockPluginManager).dependencyManager
 
         registerPlugin.register(name, value)
       }

--- a/plugins/src/test/scala/org/apache/toree/plugins/dependencies/DependencyManagerSpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/dependencies/DependencyManagerSpec.scala
@@ -16,9 +16,11 @@
  */
 package org.apache.toree.plugins.dependencies
 
-import org.scalatest.{OneInstancePerTest, Matchers, FunSpec}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class DependencyManagerSpec extends FunSpec with Matchers with OneInstancePerTest {
+class DependencyManagerSpec extends AnyFunSpec with Matchers with OneInstancePerTest {
   private val dependencyManager = new DependencyManager
 
   describe("DependencyManager") {

--- a/plugins/src/test/scala/org/apache/toree/plugins/dependencies/DependencySpec.scala
+++ b/plugins/src/test/scala/org/apache/toree/plugins/dependencies/DependencySpec.scala
@@ -16,10 +16,12 @@
  */
 package org.apache.toree.plugins.dependencies
 
-import org.scalatest.{FunSpec, OneInstancePerTest, Matchers}
+import org.scalatest.OneInstancePerTest
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 
-class DependencySpec extends FunSpec with Matchers with OneInstancePerTest {
+class DependencySpec extends AnyFunSpec with Matchers with OneInstancePerTest {
   import scala.reflect.runtime.universe._
 
   describe("Dependency") {

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -45,15 +45,15 @@ object Dependencies {
 
   val joptSimple = "net.sf.jopt-simple" % "jopt-simple" % "4.9" // MIT
 
-  val mockito = "org.mockito" % "mockito-all" % "1.10.19" // MIT
-
   val playJson = "com.typesafe.play" %% "play-json" % "2.7.4" // Apache v2
 
   val scalaCompiler = Def.setting{ "org.scala-lang" % "scala-compiler" % scalaVersion.value } // BSD 3-clause
   val scalaLibrary = Def.setting{ "org.scala-lang" % "scala-library" % scalaVersion.value } // BSD 3-clause
   val scalaReflect = Def.setting{ "org.scala-lang" % "scala-reflect" % scalaVersion.value } // BSD 3-clause
 
-  val scalaTest = "org.scalatest" %% "scalatest" % "3.0.8" // Apache v2
+  val scalaTest = "org.scalatest" %% "scalatest" % "3.2.16" // Apache v2
+  val scalaTestMockito = "org.scalatestplus" %% "mockito-4-11" % "3.2.16.0" // Apache v2
+  val mockitoInline = "org.mockito" % "mockito-inline" % "4.11.0" // MIT
 
   val slf4jApi = "org.slf4j" % "slf4j-api" % "1.7.32" // MIT
 

--- a/protocol/src/test/scala/org/apache/toree/comm/CommCallbacksSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/comm/CommCallbacksSpec.scala
@@ -21,9 +21,10 @@ package org.apache.toree.comm
 
 import org.apache.toree.comm.CommCallbacks._
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class CommCallbacksSpec extends FunSpec with Matchers {
+class CommCallbacksSpec extends AnyFunSpec with Matchers {
 
   private val testOpenCallback: OpenCallback = (_, _, _, _) => {}
   private val testMsgCallback: MsgCallback = (_, _, _) => {}

--- a/protocol/src/test/scala/org/apache/toree/comm/CommManagerSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/comm/CommManagerSpec.scala
@@ -24,11 +24,13 @@ import org.apache.toree.kernel.protocol.v5.content.{CommClose, CommOpen}
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.Answer
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.mockito.Mockito._
-import org.mockito.Matchers.{eq => mockEq, _}
+import org.mockito.ArgumentMatchers.{eq => mockEq, _}
 
-class CommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
+class CommManagerSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach
   with MockitoSugar
 {
   private val TestTargetName = "some target"
@@ -46,16 +48,16 @@ class CommManagerSpec extends FunSpec with Matchers with BeforeAndAfter
   private var mockCommRegistrar: CommRegistrar = _
   private var commManager: CommManager = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockCommWriter = mock[CommWriter]
     mockCommRegistrar = mock[CommRegistrar]
-    doReturn(mockCommRegistrar).when(mockCommRegistrar)
+    doReturn(mockCommRegistrar, Nil: _*).when(mockCommRegistrar)
       .register(anyString())
-    doReturn(mockCommRegistrar).when(mockCommRegistrar)
+    doReturn(mockCommRegistrar, Nil: _*).when(mockCommRegistrar)
       .addOpenHandler(any(classOf[OpenCallback]))
-    doReturn(mockCommRegistrar).when(mockCommRegistrar)
+    doReturn(mockCommRegistrar, Nil: _*).when(mockCommRegistrar)
       .addCloseHandler(any(classOf[CloseCallback]))
-    doReturn(mockCommRegistrar).when(mockCommRegistrar)
+    doReturn(mockCommRegistrar, Nil: _*).when(mockCommRegistrar)
       .withTarget(anyString())
 
     commManager = newCommManager(mockCommRegistrar, mockCommWriter)

--- a/protocol/src/test/scala/org/apache/toree/comm/CommRegistrarSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/comm/CommRegistrarSpec.scala
@@ -22,10 +22,12 @@ import java.util.UUID
 import org.apache.toree.comm.CommCallbacks.{CloseCallback, MsgCallback, OpenCallback}
 import org.mockito.Mockito._
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class CommRegistrarSpec extends FunSpec with Matchers with MockitoSugar
-  with BeforeAndAfter
+class CommRegistrarSpec extends AnyFunSpec with Matchers with MockitoSugar
+  with BeforeAndAfterEach
 {
   private val TestTargetName = "some target name"
   private val TestCommId = UUID.randomUUID().toString
@@ -36,7 +38,7 @@ class CommRegistrarSpec extends FunSpec with Matchers with MockitoSugar
   private var commStorage: CommStorage = _
   private var commRegistrar: CommRegistrar = _
 
-  before {
+  override def beforeEach(): Unit = {
     commStorage = new CommStorage()
     commRegistrar = new CommRegistrar(commStorage)
   }

--- a/protocol/src/test/scala/org/apache/toree/comm/CommStorageSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/comm/CommStorageSpec.scala
@@ -21,11 +21,13 @@ import org.apache.toree.kernel.protocol.v5
 import org.apache.toree.kernel.protocol.v5.UUID
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, Matchers, FunSpec}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.collection.{immutable, mutable}
 
-class CommStorageSpec extends FunSpec with Matchers with BeforeAndAfter
+class CommStorageSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach
   with MockitoSugar
 {
   private val TestTargetName = "some target"
@@ -37,7 +39,7 @@ class CommStorageSpec extends FunSpec with Matchers with BeforeAndAfter
   private var linkStorage: mutable.Map[String, immutable.IndexedSeq[UUID]] = _
   private var commStorage: CommStorage = _
 
-  before {
+  override def beforeEach(): Unit = {
     mockLinks = mock[immutable.IndexedSeq[v5.UUID]]
     mockCommCallbacks = mock[CommCallbacks]
     callbackStorage = new mutable.HashMap[String, CommCallbacks]()
@@ -208,10 +210,10 @@ class CommStorageSpec extends FunSpec with Matchers with BeforeAndAfter
       it("should return Some callbacks if the Comm id is linked") {
         val expected = mockCommCallbacks
 
-        val spyCommStorage = spy(commStorage)
-        doReturn(Some(TestTargetName)).when(spyCommStorage)
+        val spyCommStorage = spy[CommStorage](commStorage)
+        doReturn(Some(TestTargetName), Nil: _*).when(spyCommStorage)
           .getTargetFromCommId(TestCommId)
-        doReturn(Some(expected)).when(spyCommStorage)
+        doReturn(Some(expected), Nil: _*).when(spyCommStorage)
           .getTargetCallbacks(TestTargetName)
 
         spyCommStorage.getCommIdCallbacks(TestCommId) should be (Some(expected))

--- a/protocol/src/test/scala/org/apache/toree/comm/CommWriterSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/comm/CommWriterSpec.scala
@@ -22,12 +22,14 @@ import java.util.UUID
 import org.apache.toree.kernel.protocol.v5
 import org.apache.toree.kernel.protocol.v5._
 import org.apache.toree.kernel.protocol.v5.content._
-import org.mockito.Matchers._
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
-class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
+class CommWriterSpec extends AnyFunSpec with Matchers with BeforeAndAfterEach
   with MockitoSugar
 {
   private val TestCommId = UUID.randomUUID().toString
@@ -41,8 +43,8 @@ class CommWriterSpec extends FunSpec with Matchers with BeforeAndAfter
 
   private var commWriter: CommWriter = _
 
-  before {
-    commWriter = spy(new TestCommWriter())
+  override def beforeEach(): Unit = {
+    commWriter = spy[CommWriter](new TestCommWriter())
   }
 
   describe("CommWriter") {

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/HeaderBuilderSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/HeaderBuilderSpec.scala
@@ -17,9 +17,10 @@
 
 package org.apache.toree.kernel.protocol.v5
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
-class HeaderBuilderSpec extends FunSpec with Matchers {
+class HeaderBuilderSpec extends AnyFunSpec with Matchers {
   describe("HeaderBuilder") {
     describe("#create") {
       it("should set the msg_id field to a unique ID if none is provided") {

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/HeaderSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/HeaderSpec.scala
@@ -17,10 +17,11 @@
 
 package org.apache.toree.kernel.protocol.v5
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsPath, JsValue, Json, JsonValidationError}
 
-class HeaderSpec extends FunSpec with Matchers {
+class HeaderSpec extends AnyFunSpec with Matchers {
   val headerJson: JsValue = Json.parse("""
   {
     "msg_id": "<UUID>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/KMBuilderSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/KMBuilderSpec.scala
@@ -18,10 +18,11 @@
 package org.apache.toree.kernel.protocol.v5
 
 import org.apache.toree.kernel.protocol.v5.content.{CommOpen, StreamContent}
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class KMBuilderSpec extends FunSpec with Matchers {
+class KMBuilderSpec extends AnyFunSpec with Matchers {
   describe("KMBuilder") {
     val emptyKM = KernelMessage(
       ids          = Seq(),

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ClearOutputSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ClearOutputSpec.scala
@@ -18,10 +18,11 @@
 package org.apache.toree.kernel.protocol.v5.content
 
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class ClearOutputSpec extends FunSpec with Matchers {
+class ClearOutputSpec extends AnyFunSpec with Matchers {
   val clearOutputJson: JsValue = Json.parse("""
   {
     "wait": true

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CommCloseSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CommCloseSpec.scala
@@ -18,10 +18,11 @@
 package org.apache.toree.kernel.protocol.v5.content
 
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class CommCloseSpec extends FunSpec with Matchers {
+class CommCloseSpec extends AnyFunSpec with Matchers {
   val commCloseJson: JsValue = Json.parse("""
   {
     "comm_id": "<UUID>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CommMsgSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CommMsgSpec.scala
@@ -17,12 +17,13 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 import org.apache.toree.kernel.protocol.v5._
 
-class CommMsgSpec extends FunSpec with Matchers {
+class CommMsgSpec extends AnyFunSpec with Matchers {
   val commMsgJson: JsValue = Json.parse("""
   {
     "comm_id": "<UUID>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CommOpenSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CommOpenSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 import org.apache.toree.kernel.protocol.v5.MsgData
 
-class CommOpenSpec extends FunSpec with Matchers {
+class CommOpenSpec extends AnyFunSpec with Matchers {
   val commOpenJson: JsValue = Json.parse("""
   {
     "comm_id": "<UUID>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplyErrorSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplyErrorSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class CompleteReplyErrorSpec extends FunSpec with Matchers {
+class CompleteReplyErrorSpec extends AnyFunSpec with Matchers {
   val completeReplyErrorJson: JsValue = Json.parse("""
   {
     "matches": [],

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplyOkSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplyOkSpec.scala
@@ -17,10 +17,11 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class CompleteReplyOkSpec extends FunSpec with Matchers {
+class CompleteReplyOkSpec extends AnyFunSpec with Matchers {
   val completeReplyOkJson: JsValue = Json.parse("""
   {
     "matches": [],

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteReplySpec.scala
@@ -17,10 +17,11 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.{JsPath, JsValue, Json, JsonValidationError}
 
-class CompleteReplySpec extends FunSpec with Matchers {
+class CompleteReplySpec extends AnyFunSpec with Matchers {
 
 
   val completeReplyJson: JsValue = Json.parse("""

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/CompleteRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class CompleteRequestSpec extends FunSpec with Matchers {
+class CompleteRequestSpec extends AnyFunSpec with Matchers {
   val completeRequestJson: JsValue = Json.parse("""
   {
     "code": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ConnectReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ConnectReplySpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json.{JsPath, JsValue, Json}
 
-class ConnectReplySpec extends FunSpec with Matchers {
+class ConnectReplySpec extends AnyFunSpec with Matchers {
 
 
   val connectReplyJson: JsValue = Json.parse("""

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ConnectRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ConnectRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class ConnectRequestSpec extends FunSpec with Matchers {
+class ConnectRequestSpec extends AnyFunSpec with Matchers {
   val connectRequestJson: JsValue = Json.parse("""
   {}
   """)

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/DisplayDataSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/DisplayDataSpec.scala
@@ -17,14 +17,13 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.FunSuite
-
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 import org.apache.toree.kernel.protocol.v5._
 
-class DisplayDataSpec extends FunSpec with Matchers {
+class DisplayDataSpec extends AnyFunSpec with Matchers {
   val displayDataJson: JsValue = Json.parse("""
   {
     "source": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ErrorContentSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ErrorContentSpec.scala
@@ -17,10 +17,11 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json._
 
-class ErrorContentSpec extends FunSpec with Matchers {
+class ErrorContentSpec extends AnyFunSpec with Matchers {
   val errorJson: JsValue = Json.parse("""
   {
     "ename": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteInputSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteInputSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class ExecuteInputSpec extends FunSpec with Matchers {
+class ExecuteInputSpec extends AnyFunSpec with Matchers {
   val executeInputJson: JsValue = Json.parse("""
   {
     "code": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplyAbortSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplyAbortSpec.scala
@@ -18,11 +18,12 @@
 package org.apache.toree.kernel.protocol.v5.content
 
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class ExecuteReplyAbortSpec extends FunSpec with Matchers {
+class ExecuteReplyAbortSpec extends AnyFunSpec with Matchers {
   val executeReplyAbortJson: JsValue = Json.parse("""
   {
     "status": "abort",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplyErrorSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplyErrorSpec.scala
@@ -17,13 +17,14 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
 import org.apache.toree.kernel.protocol.v5._
 
-class ExecuteReplyErrorSpec extends FunSpec with Matchers {
+class ExecuteReplyErrorSpec extends AnyFunSpec with Matchers {
   val executeReplyErrorJson: JsValue = Json.parse("""
   {
     "status": "error",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplyOkSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplyOkSpec.scala
@@ -17,13 +17,14 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
 import org.apache.toree.kernel.protocol.v5._
 
-class ExecuteReplyOkSpec extends FunSpec with Matchers {
+class ExecuteReplyOkSpec extends AnyFunSpec with Matchers {
   val executeReplyOkJson: JsValue = Json.parse("""
   {
     "status": "ok",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteReplySpec.scala
@@ -18,11 +18,12 @@
 package org.apache.toree.kernel.protocol.v5.content
 
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class ExecuteReplySpec extends FunSpec with Matchers {
+class ExecuteReplySpec extends AnyFunSpec with Matchers {
   val executeReplyJson: JsValue = Json.parse("""
   {
     "status": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteRequestSpec.scala
@@ -17,12 +17,13 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{Matchers, FunSpec}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 import org.apache.toree.kernel.protocol.v5._
 
-class ExecuteRequestSpec extends FunSpec with Matchers {
+class ExecuteRequestSpec extends AnyFunSpec with Matchers {
   val executeRequestJson: JsValue = Json.parse("""
   {
     "code": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteResultSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ExecuteResultSpec.scala
@@ -17,13 +17,14 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
 import org.apache.toree.kernel.protocol.v5._
 
-class ExecuteResultSpec extends FunSpec with Matchers {
+class ExecuteResultSpec extends AnyFunSpec with Matchers {
   val executeResultJson: JsValue = Json.parse("""
   {
     "execution_count": 999,

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/HistoryReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/HistoryReplySpec.scala
@@ -17,13 +17,14 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
 import org.apache.toree.kernel.protocol.v5._
 
-class HistoryReplySpec extends FunSpec with Matchers {
+class HistoryReplySpec extends AnyFunSpec with Matchers {
   val historyReplyJson: JsValue = Json.parse("""
   {
     "history": ["<STRING>", "<STRING2>", "<STRING3>"]

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/HistoryRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/HistoryRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class HistoryRequestSpec extends FunSpec with Matchers {
+class HistoryRequestSpec extends AnyFunSpec with Matchers {
   val historyRequestJson: JsValue = Json.parse("""
   {
     "output": true,

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InputReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InputReplySpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class InputReplySpec extends FunSpec with Matchers {
+class InputReplySpec extends AnyFunSpec with Matchers {
   val inputReplyJson: JsValue = Json.parse("""
   {
     "value": "<STRING>"

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InputRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InputRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class InputRequestSpec extends FunSpec with Matchers {
+class InputRequestSpec extends AnyFunSpec with Matchers {
   val inputRequestJson: JsValue = Json.parse("""
   {
     "prompt": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectReplyErrorSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectReplyErrorSpec.scala
@@ -18,11 +18,12 @@
 package org.apache.toree.kernel.protocol.v5.content
 
 import org.apache.toree.kernel.protocol.v5._
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class InspectReplyErrorSpec extends FunSpec with Matchers {
+class InspectReplyErrorSpec extends AnyFunSpec with Matchers {
   val inspectReplyErrorJson: JsValue = Json.parse("""
   {
     "status": "error",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectReplyOkSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectReplyOkSpec.scala
@@ -17,13 +17,14 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
 import org.apache.toree.kernel.protocol.v5._
 
-class InspectReplyOkSpec extends FunSpec with Matchers {
+class InspectReplyOkSpec extends AnyFunSpec with Matchers {
   val inspectReplyOkJson: JsValue = Json.parse("""
   {
     "status": "ok",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectReplySpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class InspectReplySpec extends FunSpec with Matchers {
+class InspectReplySpec extends AnyFunSpec with Matchers {
   val inspectReplyJson: JsValue = Json.parse("""
   {
     "status": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/InspectRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class InspectRequestSpec extends FunSpec with Matchers {
+class InspectRequestSpec extends AnyFunSpec with Matchers {
   val inspectRequestJson: JsValue = Json.parse("""
   {
     "code": "<STRING>",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoReplySpec.scala
@@ -18,11 +18,12 @@
 package org.apache.toree.kernel.protocol.v5.content
 
 import org.apache.toree.kernel.protocol.v5.LanguageInfo
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class KernelInfoReplySpec extends FunSpec with Matchers {
+class KernelInfoReplySpec extends AnyFunSpec with Matchers {
   val kernelInfoReplyJson: JsValue = Json.parse("""
   {
     "protocol_version": "x.y.z",

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelInfoRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class KernelInfoRequestSpec extends FunSpec with Matchers {
+class KernelInfoRequestSpec extends AnyFunSpec with Matchers {
   val kernelInfoRequestJson: JsValue = Json.parse("""
   {}
   """)

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelStatusSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/KernelStatusSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json.{JsPath, JsValue, Json}
 
-class KernelStatusSpec extends FunSpec with Matchers {
+class KernelStatusSpec extends AnyFunSpec with Matchers {
   val kernelStatusJson: JsValue = Json.parse("""
   {
     "execution_state": "<STRING>"

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ShutdownReplySpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ShutdownReplySpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class ShutdownReplySpec extends FunSpec with Matchers {
+class ShutdownReplySpec extends AnyFunSpec with Matchers {
   val shutdownReplyJson: JsValue = Json.parse("""
   {
     "restart": true

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ShutdownRequestSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/ShutdownRequestSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class ShutdownRequestSpec extends FunSpec with Matchers {
+class ShutdownRequestSpec extends AnyFunSpec with Matchers {
   val shutdownRequestJson: JsValue = Json.parse("""
   {
     "restart": true

--- a/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/StreamContentSpec.scala
+++ b/protocol/src/test/scala/org/apache/toree/kernel/protocol/v5/content/StreamContentSpec.scala
@@ -17,11 +17,12 @@
 
 package org.apache.toree.kernel.protocol.v5.content
 
-import org.scalatest.{FunSpec, Matchers}
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import play.api.libs.json.JsonValidationError
 import play.api.libs.json._
 
-class StreamContentSpec extends FunSpec with Matchers {
+class StreamContentSpec extends AnyFunSpec with Matchers {
   val streamJson: JsValue = Json.parse("""
   {
     "text": "<STRING>",

--- a/scala-interpreter/src/test/scala/integration/interpreter/scala/AddExternalJarMagicSpecForIntegration.scala
+++ b/scala-interpreter/src/test/scala/integration/interpreter/scala/AddExternalJarMagicSpecForIntegration.scala
@@ -26,12 +26,15 @@ import org.apache.toree.interpreter._
 import org.apache.toree.kernel.api.KernelLike
 import org.apache.toree.kernel.interpreter.scala.ScalaInterpreter
 import org.scalatestplus.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfter, FunSpec, Ignore, Matchers}
+import org.scalatest.Ignore
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 
 @SbtForked
 @Ignore
 class AddExternalJarMagicSpecForIntegration
-  extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter
+  extends AnyFunSpec with Matchers with MockitoSugar with BeforeAndAfterEach
 {
 
   private val outputResult = new ByteArrayOutputStream()
@@ -39,7 +42,7 @@ class AddExternalJarMagicSpecForIntegration
   private var tempdir: File = _
 
 
-  before {
+  override def beforeEach(): Unit = {
     interpreter = new ScalaInterpreter {
       override protected def bindKernelVariable(kernel: KernelLike): Unit = { }
     }
@@ -51,7 +54,7 @@ class AddExternalJarMagicSpecForIntegration
     tempdir = JarUtils.createTemporaryDir()
   }
 
-  after {
+  override def afterEach(): Unit = {
     interpreter.stop()
     outputResult.reset()
   }

--- a/scala-interpreter/src/test/scala/integration/interpreter/scala/JVMReprSpec.scala
+++ b/scala-interpreter/src/test/scala/integration/interpreter/scala/JVMReprSpec.scala
@@ -28,29 +28,32 @@ import org.apache.toree.interpreter.Results.Success
 import org.apache.toree.kernel.api.{DisplayMethodsLike, KernelLike}
 import org.apache.toree.kernel.interpreter.scala.ScalaInterpreter
 import org.mockito.Mockito.doReturn
-import org.scalatest.{BeforeAndAfter, FunSpec, Ignore, Matchers}
+import org.scalatest.BeforeAndAfterEach
+import org.scalatest.Ignore
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.Random
 
 @SbtForked
 @Ignore
-class JVMReprSpec extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter {
+class JVMReprSpec extends AnyFunSpec with Matchers with MockitoSugar with BeforeAndAfterEach {
 
   private val outputResult = new ByteArrayOutputStream()
   private var interpreter: Interpreter = _
 
-  before {
+  override def beforeEach(): Unit = {
     val mockKernel = mock[KernelLike]
     val mockDisplayMethods = mock[DisplayMethodsLike]
-    doReturn(mockDisplayMethods).when(mockKernel).display
+    doReturn(mockDisplayMethods, Nil: _*).when(mockKernel).display
 
     interpreter = new ScalaInterpreter().init(mockKernel)
 
     StreamState.setStreams(outputStream = outputResult)
   }
 
-  after {
+  override def afterEach(): Unit = {
     interpreter.stop()
     outputResult.reset()
   }

--- a/src/test/scala/system/StdinForSystemSpec.scala
+++ b/src/test/scala/system/StdinForSystemSpec.scala
@@ -20,13 +20,15 @@ package system
 import org.apache.toree.kernel.protocol.v5.client.SparkKernelClient
 import org.scalatest.concurrent.Eventually
 import org.scalatest.time.{Seconds, Milliseconds, Span}
-import org.scalatest.{BeforeAndAfterAll, FunSpec, Matchers}
+import org.scalatest.BeforeAndAfterAll
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers
 import test.utils.root.{SparkKernelClientDeployer, SparkKernelDeployer}
 
 /**
  * Tests all stdin-related functionality between the client and kernel.
  */
-class StdinForSystemSpec extends FunSpec with Matchers with BeforeAndAfterAll
+class StdinForSystemSpec extends AnyFunSpec with Matchers with BeforeAndAfterAll
   with Eventually
 {
   implicit override val patienceConfig = PatienceConfig(


### PR DESCRIPTION
This is part of https://github.com/apache/incubator-toree/pull/199

Co-authored-by: Luciano Resende <lresende@apple.com>
Co-authored-by: Cheng Pan <chengpan@apache.org>

This PR aims to upgrade scalatest to 3.2 and the corresponding mockito to 4.11 to prepare support for Scala 2.13

The change is verified by `examples/magic-tutorial.ipynb`

<img width="1957" alt="image" src="https://github.com/apache/incubator-toree/assets/26535726/1cb71e20-769b-4608-b500-d59ce28466d6">
