### PR TITLE
[TOREE-546] Mitigate ZeroMQSocketRunnableSpec hang

### DIFF
--- a/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
@@ -58,6 +58,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
     mockSocketType = SocketType.RAW // mock[SocketType]
     zmqContext = ZMQ.context(1)
     pubSocket = zmqContext.socket(SocketType.PUB)
+    pubSocket.setLinger(10 * 1000)
   }
 
   after {

--- a/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
@@ -58,7 +58,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
     mockSocketType = SocketType.RAW // mock[SocketType]
     zmqContext = ZMQ.context(1)
     pubSocket = zmqContext.socket(SocketType.PUB)
-    pubSocket.setLinger(10 * 1000)
+    pubSocket.setLinger(0)
   }
 
   after {


### PR DESCRIPTION
This is the second try to fix the ZeroMQSocketRunnableSpec hang. Unfortunately, the previous try https://github.com/apache/incubator-toree/pull/205 seems not help.

The stacktrace is
```
[info]   - should set the linger option when provided *** FAILED *** (124 milliseconds)
[info]     java.lang.AssertionError: assertion failed: Runnable is not processing or is closed!
[info]     at scala.Predef$.assert(Predef.scala:223)
[info]     at org.apache.toree.communication.socket.ZeroMQSocketRunnable.close(ZeroMQSocketRunnable.scala:187)
[info]     at org.apache.toree.communication.socket.ZeroMQSocketRunnableSpec.$anonfun$new$12(ZeroMQSocketRunnableSpec.scala:138)
...
```

This time I follow the guidance of `ZMQ.Context#close()`'s JavaDoc to set ZMQ_LINGER to 0, hope this help.

> Warning
>
> As ZMQ_LINGER defaults to "infinite", by default this method will block indefinitely if there are any pending connects or sends. We strongly recommend to
> - set ZMQ_LINGER to zero on all sockets
> - close all sockets, before calling this method