### PR TITLE
[TOREE-548] Call shutdown to close ZQM Context in ZeroMQSocketRunnableSpec

### DIFF
--- a/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
@@ -22,6 +22,7 @@ import org.scalatest.time.{Milliseconds, Seconds, Span}
 import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
 import org.zeromq.{SocketType, ZMQ}
 import org.zeromq.ZMQ.{Context, Socket}
+import zmq.Ctx
 
 import scala.util.Try
 
@@ -61,7 +62,14 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
   }
 
   after {
-    Try(zmqContext.close())
+    Try {
+      val ctxFiled = classOf[ZMQ.Context].getClass.getDeclaredField("ctx")
+      ctxFiled.setAccessible(true)
+      val ctx = ctxFiled.get(zmqContext).asInstanceOf[Ctx]
+      val shutdownMethod = classOf[Ctx].getDeclaredMethod("shutdown")
+      shutdownMethod.setAccessible(true)
+      shutdownMethod.invoke(ctx)
+    }
   }
 
   describe("ZeroMQSocketRunnable") {


### PR DESCRIPTION
This is the third attempt to fix the test hang issue ...

```
"pool-5-thread-1-ScalaTest-running-ZeroMQSocketRunnableSpec" #76 prio=5 os_prio=0 tid=0x00007efcd5e53000 nid=0x54954 runnable [0x00007efc2effb000]
   java.lang.Thread.State: RUNNABLE
	at sun.nio.ch.EPollArrayWrapper.epollWait(Native Method)
	at sun.nio.ch.EPollArrayWrapper.poll(EPollArrayWrapper.java:269)
	at sun.nio.ch.EPollSelectorImpl.doSelect(EPollSelectorImpl.java:93)
	at sun.nio.ch.SelectorImpl.lockAndDoSelect(SelectorImpl.java:86)
	- locked <0x00000006f93f8448> (a sun.nio.ch.Util$3)
	- locked <0x00000006f93f8430> (a java.util.Collections$UnmodifiableSet)
	- locked <0x00000006f8c1f180> (a sun.nio.ch.EPollSelectorImpl)
	at sun.nio.ch.SelectorImpl.select(SelectorImpl.java:97)
	at zmq.Signaler.waitEvent(Signaler.java:166)
	at zmq.Mailbox.recv(Mailbox.java:91)
	at zmq.Ctx.terminate(Ctx.java:302)
	at org.zeromq.ZMQ$Context.term(ZMQ.java:671)
	at org.zeromq.ZMQ$Context.close(ZMQ.java:779)
	at org.apache.toree.communication.socket.ZeroMQSocketRunnableSpec.$anonfun$new$3(ZeroMQSocketRunnableSpec.scala:65)
	at org.apache.toree.communication.socket.ZeroMQSocketRunnableSpec$$Lambda$9113/65813533.apply$mcV$sp(Unknown Source)
	at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
	at scala.util.Try$.apply(Try.scala:213)
	at org.apache.toree.communication.socket.ZeroMQSocketRunnableSpec.$anonfun$new$2(ZeroMQSocketRunnableSpec.scala:65)
	at org.apache.toree.communication.socket.ZeroMQSocketRunnableSpec$$Lambda$8887/1440611680.apply(Unknown Source)
	at org.scalatest.BeforeAndAfter.$anonfun$runTest$1(BeforeAndAfter.scala:219)
        ...
```

It uses reflection to call `Ctx#shutdown` to skip waiting `DONE` message

```
Command cmd = termMailbox.recv(WAIT_FOREVER);
```

So in theory, it could solve the hang problem thoroughly (maybe ...