### PR TITLE
[TOREE-549] Fix flaky test by closing pubSocket quietly

### DIFF
--- a/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
+++ b/communication/src/test/scala/org/apache/toree/communication/socket/ZeroMQSocketRunnableSpec.scala
@@ -134,7 +134,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
           actual should be (expected)
         }
 
-        runnable.close()
+        Try(runnable.close())
       }
 
       it("should set the identity option when provided") {
@@ -157,7 +157,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
           actual should be (expected)
         }
 
-        runnable.close()
+        Try(runnable.close())
       }
 
       it("should close the thread when closed"){
@@ -177,7 +177,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
           runnable.isProcessing should be (true)
         }
 
-        runnable.close()
+        Try(runnable.close())
 
         eventually{
           thread.isAlive should be (false)
@@ -203,7 +203,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
           runnable.isProcessing should be (true)
         }
 
-        runnable.close()
+        Try(runnable.close())
 
         eventually {
           runnable.isProcessing should be (false)
@@ -227,7 +227,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
           runnable.isProcessing should be (true)
         }
 
-        runnable.close()
+        Try(runnable.close())
       }
     }
 
@@ -249,7 +249,7 @@ class ZeroMQSocketRunnableSpec extends FunSpec with Matchers
             runnable.isProcessing should be (true)
           }
 
-          runnable.close()
+          Try(runnable.close())
 
           eventually{
             thread.isAlive should be(false)


### PR DESCRIPTION
I noticed the following test failed sometimes, considering the close action is a kind of resource cleanup, we should ignore the error instead of failing the test.

```
[info]   - should set the linger option when provided *** FAILED *** (6 milliseconds)
[info]     java.lang.AssertionError: assertion failed: Runnable is not processing or is closed!
[info]     at scala.Predef$.assert(Predef.scala:223)
[info]     at org.apache.toree.communication.socket.ZeroMQSocketRunnable.close(ZeroMQSocketRunnable.scala:187)
[info]     at org.apache.toree.communication.socket.ZeroMQSocketRunnableSpec.$anonfun$new$15(ZeroMQSocketRunnableSpec.scala:145)
```