### PR TITLE
Revert "[TOREE-543] Fix and enable JVMReprSpec"

### DIFF
--- a/scala-interpreter/build.sbt
+++ b/scala-interpreter/build.sbt
@@ -17,6 +17,5 @@ import sbt.Tests.{Group, SubProcess}
  *  limitations under the License
  */
 
-Test / fork := true
 libraryDependencies ++= Dependencies.sparkAll.value
 libraryDependencies += "com.github.jupyter" % "jvm-repr" % "0.1.0"

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -155,7 +155,7 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
      doQuietly {
 
        bind(
-         "kernel", "org.apache.toree.kernel.api.KernelLike",
+         "kernel", "org.apache.toree.kernel.api.Kernel",
          kernel, List( """@transient implicit""")
        )
      }

--- a/scala-interpreter/src/test/scala/integration/interpreter/scala/JVMReprSpec.scala
+++ b/scala-interpreter/src/test/scala/integration/interpreter/scala/JVMReprSpec.scala
@@ -28,12 +28,13 @@ import org.apache.toree.interpreter.Results.Success
 import org.apache.toree.kernel.api.{DisplayMethodsLike, KernelLike}
 import org.apache.toree.kernel.interpreter.scala.ScalaInterpreter
 import org.mockito.Mockito.doReturn
-import org.scalatest.{BeforeAndAfter, FunSpec, Matchers}
+import org.scalatest.{BeforeAndAfter, FunSpec, Ignore, Matchers}
 import org.scalatestplus.mockito.MockitoSugar
 
 import scala.util.Random
 
 @SbtForked
+@Ignore
 class JVMReprSpec extends FunSpec with Matchers with MockitoSugar with BeforeAndAfter {
 
   private val outputResult = new ByteArrayOutputStream()


### PR DESCRIPTION
Reverts apache/incubator-toree#209

It fixes the UT, but unfortunately, breaks the real workload ...

<img width="1020" alt="image" src="https://github.com/apache/incubator-toree/assets/26535726/87b75d7b-7b16-4520-b709-3e1c89583752">

We need to explore another way to adjust the test case, or change the implementation.