### PR TITLE
[TOREE-550] Upgrade Akka 2.6.21

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -21,16 +21,16 @@ import scala.util.Properties
 object Dependencies {
 
   // Libraries
-
-  val akkaActor = "com.typesafe.akka" %% "akka-actor" % "2.5.31" // Apache v2
-  val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % "2.5.31" // Apache v2
-  val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % "2.5.31" // Apache v2
+  val akkaVersion = "2.6.21" // The latest version under Apache v2
+  val akkaActor = "com.typesafe.akka" %% "akka-actor" % akkaVersion // Apache v2
+  val akkaSlf4j = "com.typesafe.akka" %% "akka-slf4j" % akkaVersion // Apache v2
+  val akkaTestkit = "com.typesafe.akka" %% "akka-testkit" % akkaVersion // Apache v2
 
   val clapper = "org.clapper" %% "classutil" % "1.5.1" // BSD 3-clause license, used for detecting plugins
 
   val commonsExec = "org.apache.commons" % "commons-exec" % "1.3" // Apache v2
 
-  val config = "com.typesafe" % "config" % "1.3.0" // Apache v2
+  val config = "com.typesafe" % "config" % "1.4.2" // Apache v2
 
   val coursierVersion = "1.0.3"
   val coursier = "io.get-coursier" %% "coursier" % coursierVersion // Apache v2


### PR DESCRIPTION
Upgrading Akka to 2.6.21 to prepare to support Scala 2.13, typesafe-config is upgraded to 1.4.2 correspondingly.

Akka 2.6.21 is the latest version released under the Apache V2 license. Since 2.7.0, Akka changed the license from Apache V2 to BSL v1.1, the latter is not allowed by Apache projects.

In the future, we may consider migrating to Apache Pekko due to license issues.

> Apache Pekko is a fork of [Akka](https://github.com/akka/akka) 2.6.x, prior to the Akka project’s adoption of the Business Source License.

https://www.thestack.technology/akka-license-change-lightbend-opensource/
https://apache.org/legal/resolved.html#category-x
https://pekko.apache.org/what-is-pekko.html