### PR TITLE
[TOREE-553] Correct the behavior of `make dev`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean: clean-dist
 	@rm -f .toree-dev-image
 	@-docker rmi -f $(TOREE_DEV_IMAGE)
 
-.toree-dev-image:
+.toree-dev-image: .clean-toree-dev-image
 	@docker build -t $(TOREE_DEV_IMAGE) -f Dockerfile.toree-dev .
 	touch $@
 
@@ -161,7 +161,7 @@ dist: dist/toree pip-release
 dev: DOCKER_WORKDIR=/srv/toree/etc/examples/notebooks
 dev: SUSPEND=n
 dev: DEBUG_PORT=5005
-dev: .toree-dev-image dist
+dev: dist .toree-dev-image
 	@$(DOCKER) \
 		-e SPARK_OPTS="--master=local[4] --driver-java-options=-agentlib:jdwp=transport=dt_socket,server=y,suspend=$(SUSPEND),address=5005" \
 		-p $(DEBUG_PORT):5005 -p 8888:8888 $(TOREE_DEV_IMAGE) \

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ clean: clean-dist
 	@rm -f .toree-dev-image
 	@-docker rmi -f $(TOREE_DEV_IMAGE)
 
-.toree-dev-image: .clean-toree-dev-image
+.toree-dev-image:
 	@docker build -t $(TOREE_DEV_IMAGE) -f Dockerfile.toree-dev .
 	touch $@
 


### PR DESCRIPTION
This PR aims to improve the developer experience of the command `make dev`.

Previously, after changing the code, running `make dev` does not pick up the new assembly artifacts, which is not convenient for developers.

After the change, `make dev` becomes intuitive, it always picks up the latest assembly artifacts.