### PR TITLE
[TOREE-558] ScalaInterpreter prefer to use context classloader

### DIFF
--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -51,9 +51,9 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
   protected val logger = LoggerFactory.getLogger(this.getClass.getName)
 
-  //honors caller's context classloader. If it's set, fall back to this class's classloader.
-  private val _contextClassloader = Thread.currentThread().getContextClassLoader
-  protected val _thisClassloader =  if (_contextClassloader == null) this.getClass.getClassLoader else _contextClassloader
+  // honors caller's context classloader. If it isn't set, fall back to this class's classloader.
+  protected val _thisClassloader = Option(Thread.currentThread().getContextClassLoader)
+      .getOrElse(this.getClass.getClassLoader)
 
   protected val lastResultOut = new ByteArrayOutputStream()
 

--- a/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
+++ b/scala-interpreter/src/main/scala/org/apache/toree/kernel/interpreter/scala/ScalaInterpreter.scala
@@ -51,7 +51,9 @@ class ScalaInterpreter(private val config:Config = ConfigFactory.load) extends I
 
   protected val logger = LoggerFactory.getLogger(this.getClass.getName)
 
-  protected val _thisClassloader = this.getClass.getClassLoader
+  //honors caller's context classloader. If it's set, fall back to this class's classloader.
+  private val _contextClassloader = Thread.currentThread().getContextClassLoader
+  protected val _thisClassloader =  if (_contextClassloader == null) this.getClass.getClassLoader else _contextClassloader
 
   protected val lastResultOut = new ByteArrayOutputStream()
 


### PR DESCRIPTION
When a caller instantiates `Toree Main` and `ScalaInterpreter`, they may want to use a custom classloader to execute specific code within `ScalaInterpreter`. To facilitate this, the caller can pass a custom classloader through the current thread’s `ContextClassLoader`.

For example, in a Spark environment, all Spark framework jars are typically located in a directory such as `/opt/spark/jars`, which also includes `toree-assembly.jar`. When we submit a Spark job (e.g., using `spark-submit --conf spark.jars=MyExternalJar.jar --class org.apache.toree.Main`), any custom jars like `MyExternalJar.jar` are added by `SparkSubmit.scala` to the current thread’s `ContextClassLoader`. This classloader is then used to execute `org.apache.toree.Main` and instantiate `ScalaInterpreter` with access to the custom jars.

The following code snippet shows similar logic to `SparkSubmit.scala`, demonstrating how jars in `childClasspath` can be added to the thread’s `ContextClassLoader` before invoking `main()`:

```scala
public void main(String[] args) {
    // Add each jar in the childClasspath to the context classloader
    for (jar <- childClasspath) {
        val contextClassLoader = Thread.currentThread.getContextClassLoader
        contextClassLoader.addURL(jar.toURI.toURL)
    }

    // Execute Toree Main with the configured context classloader
    org.apache.toree.Main.main(args)
}
```

In this setup, `main()` and any objects it instantiates can use the custom `ContextClassLoader` to access additional jars specified at runtime with this PR change.