### PR TITLE
[TOREE-562] Update NOTICE for 2025

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Toree
-Copyright [2016-2020] The Apache Software Foundation
+Copyright [2016-2025] The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/)


### PR DESCRIPTION
probably needs https://github.com/apache/incubator-toree/pull/227 because the CI is now broken without that