### PR TITLE
fix issue with missing sbt in build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,14 +41,16 @@ jobs:
       TEST_DILATION: 3
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
       with:
         clean: true
-    - name: Checkout
-      uses: actions/setup-java@v2
+    - name: Setup Java
+      uses: actions/setup-java@v4
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.java }}
+        cache: sbt
+    - uses: sbt/setup-sbt@v1        
     - name: Add SBT launcher
       run: |
         mkdir -p $HOME/.sbt/launchers/1.3.12


### PR DESCRIPTION
sbt is no longer added to `ubuntu-latest` in GitHub CI. You have to install it explicitly.