### PR TITLE
Add license and description to assembly POM

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -165,7 +165,11 @@ dist/toree-legal/DISCLAIMER:
 dist/toree-legal: dist/toree-legal/LICENSE dist/toree-legal/NOTICE dist/toree-legal/DISCLAIMER
 	@cp -R etc/legal/licenses dist/toree-legal/.
 
-dist/toree: dist/toree/VERSION dist/toree/logo-64x64.png dist/toree-legal dist/toree/lib dist/toree/bin RELEASE_NOTES.md
+dist/toree/toree-assembly-$(VERSION).pom: etc/templates/toree-assembly-pom.xml
+	@mkdir -p dist/toree
+	@sed 's/@VERSION@/$(VERSION)/g' etc/templates/toree-assembly-pom.xml > dist/toree/toree-assembly-$(VERSION).pom
+
+dist/toree: dist/toree/VERSION dist/toree/logo-64x64.png dist/toree-legal dist/toree/lib dist/toree/bin dist/toree/toree-assembly-$(VERSION).pom RELEASE_NOTES.md
 	@cp -R dist/toree-legal/* dist/toree
 	@cp RELEASE_NOTES.md dist/toree/RELEASE_NOTES.md
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ RUN=$(RUN_PREFIX)$(1)$(RUN_SUFFIX)
 ENV_OPTS:=APACHE_SPARK_VERSION=$(APACHE_SPARK_VERSION) SCALA_VERSION=$(SCALA_VERSION) VERSION=$(VERSION) IS_SNAPSHOT=$(IS_SNAPSHOT)
 
 ASSEMBLY_JAR:=toree-assembly-$(VERSION)$(SNAPSHOT).jar
+ASSEMBLY_POM:=toree-assembly-$(VERSION)$(SNAPSHOT).pom
 
 help:
 	@echo '	'
@@ -165,7 +166,24 @@ dist/toree-legal/DISCLAIMER:
 dist/toree-legal: dist/toree-legal/LICENSE dist/toree-legal/NOTICE dist/toree-legal/DISCLAIMER
 	@cp -R etc/legal/licenses dist/toree-legal/.
 
-dist/toree: dist/toree/VERSION dist/toree/logo-64x64.png dist/toree-legal dist/toree/lib dist/toree/bin RELEASE_NOTES.md
+# The deployed POM is generated rather than hand-maintained so that the version
+# and the incubation disclaimer have a single source of truth. awk reads the
+# disclaimer as data, so no character in DISCLAIMER can break the substitution
+# the way it could in a sed replacement.
+dist/toree/$(ASSEMBLY_POM): etc/templates/toree-assembly-pom.xml DISCLAIMER
+	@mkdir -p dist/toree
+	@awk -v version='$(VERSION)$(SNAPSHOT)' ' \
+		$$0 == "@DISCLAIMER@" { \
+			while ((getline line < "DISCLAIMER") > 0) { \
+				if (line == "") print ""; else print "    " line \
+			} \
+			close("DISCLAIMER"); \
+			next \
+		} \
+		{ gsub(/@VERSION@/, version); print } \
+	' etc/templates/toree-assembly-pom.xml > dist/toree/$(ASSEMBLY_POM)
+
+dist/toree: dist/toree/VERSION dist/toree/logo-64x64.png dist/toree-legal dist/toree/lib dist/toree/bin dist/toree/$(ASSEMBLY_POM) RELEASE_NOTES.md
 	@cp -R dist/toree-legal/* dist/toree
 	@cp RELEASE_NOTES.md dist/toree/RELEASE_NOTES.md
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -35,6 +35,9 @@
 * Update AddJar command to support Google cloud storage
 * Fire postRunCell event after cell execution
 * Update Scala to 2.12.20 and 2.13.15
+* Deploy the `toree-assembly` jar with a complete POM carrying the license,
+  description, incubation disclaimer, project URL and SCM metadata, replacing
+  the minimal POM Maven generated when no POM was supplied
 
 ### Breaking Changes
 

--- a/build.sbt
+++ b/build.sbt
@@ -101,7 +101,15 @@ ThisBuild / packageBin / mappings := Seq(
   file("LICENSE") -> "LICENSE",
   file("NOTICE") -> "NOTICE"
 )
-ThisBuild / licenses := Seq("Apache 2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / description := "Apache Toree is a Jupyter Notebook kernel that provides interactive " +
+  "applications to connect to and use Apache Spark using Scala language. " +
+  "Apache Toree is an effort undergoing incubation at the Apache Software Foundation (ASF), " +
+  "sponsored by the Apache Incubator PMC. Incubation is required of all newly accepted projects " +
+  "until a further review indicates that the infrastructure, communications, and decision making " +
+  "process have stabilized in a manner consistent with other successful ASF projects. While " +
+  "incubation status is not necessarily a reflection of the completeness or stability of the code, " +
+  "it does indicate that the project has yet to be fully endorsed by the ASF."
+ThisBuild / licenses := Seq("Apache License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / pomExtra := {
   <parent>
     <groupId>org.apache</groupId>

--- a/build.sbt
+++ b/build.sbt
@@ -101,20 +101,29 @@ ThisBuild / packageBin / mappings := Seq(
   file("LICENSE") -> "LICENSE",
   file("NOTICE") -> "NOTICE"
 )
-ThisBuild / licenses := Seq("Apache 2" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
+// The incubation disclaimer is read from DISCLAIMER rather than repeated here, so
+// the published POMs cannot drift from the file the ASF requires us to ship. It is
+// wrapped for readability in the file, so collapse the wrapping for POM metadata.
+ThisBuild / description := {
+  val disclaimer = IO.read((ThisBuild / baseDirectory).value / "DISCLAIMER")
+    .replaceAll("\\s+", " ")
+    .trim
+  "Apache Toree is a Jupyter Notebook kernel that provides interactive " +
+    "applications to connect to and use Apache Spark using Scala language. " +
+    disclaimer
+}
+ThisBuild / licenses := Seq("Apache License, Version 2.0" -> url("https://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / pomExtra := {
   <parent>
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
-    <version>23</version>
+    <version>39</version>
   </parent>
-  <url>http://toree.apache.org/</url>
+  <url>https://toree.apache.org/</url>
   <scm>
-    <url>git@github.com:apache/incubator-toree.git</url>
-    <connection>scm:git:git@github.com:apache/incubator-toree.git</connection>
-    <developerConnection>
-      scm:git:https://gitbox.apache.org/repos/asf/incubator-toree.git
-    </developerConnection>
+    <url>https://github.com/apache/incubator-toree</url>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/incubator-toree.git</connection>
+    <developerConnection>scm:git:git@github.com:apache/incubator-toree.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 }

--- a/etc/pip_install/setup.py
+++ b/etc/pip_install/setup.py
@@ -25,28 +25,32 @@ version_ns = {}
 with open(os.path.join(here, 'toree', '_version.py')) as f:
     exec(f.read(), {}, version_ns)
 
+# The incubation disclaimer is read from the DISCLAIMER file shipped alongside
+# this package rather than repeated here, so the PyPI metadata cannot drift from
+# the copy the ASF requires the distribution to carry. The file is indented to
+# match the surrounding literal. A missing DISCLAIMER must never fail an
+# install, so fall back to the summary line on its own.
+long_description = '''
+    This package will install Apache Toree as a Jupyter kernel.
+'''
+try:
+    with open(os.path.join(here, 'DISCLAIMER')) as f:
+        disclaimer = f.read().strip()
+    long_description += '\n' + '\n'.join(
+        '    ' + line if line.strip() else '' for line in disclaimer.splitlines()
+    ) + '\n    '
+except OSError:
+    pass
+
 setup_args = dict(
     name='toree',
     author='Apache Toree Development Team',
     author_email='dev@toree.apache.org',
     description='A Jupyter kernel for enabling remote applications to interaction with Apache Spark.',
-    long_description = '''
-    This package will install Apache Toree as a Jupyter kernel.
-
-    Apache Toree is an effort undergoing incubation at the Apache Software
-    Foundation (ASF), sponsored by the Apache Incubator PMC.
-
-    Incubation is required of all newly accepted projects until a further review
-    indicates that the infrastructure, communications, and decision making process
-    have stabilized in a manner consistent with other successful ASF projects.
-
-    While incubation status is not necessarily a reflection of the completeness
-    or stability of the code, it does indicate that the project has yet to be
-    fully endorsed by the ASF.
-    ''',
-    url='http://toree.apache.org/',
+    long_description=long_description,
+    url='https://toree.apache.org/',
     version=version_ns['__version__'],
-    license='Apache License 2.0',
+    license='Apache License, Version 2.0',
     platforms=[],
     packages=['toree'],
     include_package_data=True,

--- a/etc/templates/toree-assembly-pom.xml
+++ b/etc/templates/toree-assembly-pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>23</version>
+  </parent>
+
+  <groupId>org.apache.toree</groupId>
+  <artifactId>toree-assembly</artifactId>
+  <version>@VERSION@</version>
+  <packaging>jar</packaging>
+
+  <name>Apache Toree</name>
+  <description>
+    Apache Toree is a Jupyter Notebook kernel that provides interactive
+    applications to connect to and use Apache Spark using Scala language.
+
+    Apache Toree is an effort undergoing incubation at the Apache Software
+    Foundation (ASF), sponsored by the Apache Incubator PMC. Incubation is
+    required of all newly accepted projects until a further review indicates
+    that the infrastructure, communications, and decision making process have
+    stabilized in a manner consistent with other successful ASF projects.
+    While incubation status is not necessarily a reflection of the completeness
+    or stability of the code, it does indicate that the project has yet to be
+    fully endorsed by the ASF.
+  </description>
+  <url>https://toree.apache.org/</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <url>git@github.com:apache/incubator-toree.git</url>
+    <connection>scm:git:git@github.com:apache/incubator-toree.git</connection>
+    <developerConnection>scm:git:https://gitbox.apache.org/repos/asf/incubator-toree.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+</project>

--- a/etc/templates/toree-assembly-pom.xml
+++ b/etc/templates/toree-assembly-pom.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one or more
+  contributor license agreements.  See the NOTICE file distributed with
+  this work for additional information regarding copyright ownership.
+  The ASF licenses this file to You under the Apache License, Version 2.0
+  (the "License"); you may not use this file except in compliance with
+  the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<project xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+  <modelVersion>4.0.0</modelVersion>
+
+  <parent>
+    <groupId>org.apache</groupId>
+    <artifactId>apache</artifactId>
+    <version>39</version>
+  </parent>
+
+  <groupId>org.apache.toree</groupId>
+  <artifactId>toree-assembly</artifactId>
+  <version>@VERSION@</version>
+  <packaging>jar</packaging>
+
+  <name>Apache Toree</name>
+  <!--
+    The placeholders in this file are substituted by the assembly POM rule in
+    the Makefile. The incubation disclaimer is pulled from the DISCLAIMER file
+    at the repository root rather than repeated here, so this POM cannot drift
+    from the copy the ASF requires the distribution to carry.
+  -->
+  <description>
+    Apache Toree is a Jupyter Notebook kernel that provides interactive
+    applications to connect to and use Apache Spark using Scala language.
+
+@DISCLAIMER@
+  </description>
+  <url>https://toree.apache.org/</url>
+
+  <licenses>
+    <license>
+      <name>Apache License, Version 2.0</name>
+      <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
+
+  <scm>
+    <url>https://github.com/apache/incubator-toree</url>
+    <connection>scm:git:https://gitbox.apache.org/repos/asf/incubator-toree.git</connection>
+    <developerConnection>scm:git:git@github.com:apache/incubator-toree.git</developerConnection>
+    <tag>HEAD</tag>
+  </scm>
+</project>

--- a/etc/tools/release-build.sh
+++ b/etc/tools/release-build.sh
@@ -295,7 +295,7 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
         svn ci -m"Apache Toree $RELEASE_STAGING_FOLDER"
 
         cd "$BASE_DIR/target"
-        mvn gpg:sign-and-deploy-file -DgroupId=org.apache.toree -DartifactId=toree-assembly -Dversion=$RELEASE_VERSION-incubating -Dpackaging=jar -Dfile=toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar -DrepositoryId=apache.releases.https -Durl=https://repository.apache.org/service/local/staging/deploy/maven2 -Dpassphrase=$GPG_PASSPHRASE
+        mvn gpg:sign-and-deploy-file -DgroupId=org.apache.toree -DartifactId=toree-assembly -Dversion=$RELEASE_VERSION-incubating -Dpackaging=jar -Dfile=toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar -DpomFile=toree/dist/toree/toree-assembly-$RELEASE_VERSION-incubating.pom -DrepositoryId=apache.releases.https -Durl=https://repository.apache.org/service/local/staging/deploy/maven2 -Dpassphrase=$GPG_PASSPHRASE
     fi
 
     cd "$BASE_DIR" #exit target
@@ -314,7 +314,7 @@ if [[ "$RELEASE_PUBLISH" == "true" ]]; then
     make clean dist release
 
     cd "$BASE_DIR/target"
-    mvn gpg:sign-and-deploy-file -DgroupId=org.apache.toree -DartifactId=toree-assembly -Dversion=$RELEASE_VERSION-incubating -Dpackaging=jar -Dfile=toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar -DrepositoryId=apache.releases.https -Durl=https://repository.apache.org/service/local/staging/deploy/maven2 -Dpassphrase=$GPG_PASSPHRASE
+    mvn gpg:sign-and-deploy-file -DgroupId=org.apache.toree -DartifactId=toree-assembly -Dversion=$RELEASE_VERSION-incubating -Dpackaging=jar -Dfile=toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar -DpomFile=toree/dist/toree/toree-assembly-$RELEASE_VERSION-incubating.pom -DrepositoryId=apache.releases.https -Durl=https://repository.apache.org/service/local/staging/deploy/maven2 -Dpassphrase=$GPG_PASSPHRASE
 
     cd "$BASE_DIR" #exit target
 

--- a/etc/tools/release-build.sh
+++ b/etc/tools/release-build.sh
@@ -310,11 +310,8 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
         # The passphrase reaches the plugin through MAVEN_GPG_PASSPHRASE rather than the
         # command line, where it would be visible to any local user through ps.
         mvn "$MVN_GPG_PLUGIN:sign-and-deploy-file" \
-            -DgroupId=org.apache.toree \
-            -DartifactId=toree-assembly \
-            -Dversion="$RELEASE_VERSION-incubating" \
-            -Dpackaging=jar \
             -Dfile="toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar" \
+            -DpomFile="toree/dist/toree/toree-assembly-$RELEASE_VERSION-incubating.pom" \
             -DrepositoryId=apache.releases.https \
             -Durl=https://repository.apache.org/service/local/staging/deploy/maven2
     fi
@@ -338,11 +335,8 @@ if [[ "$RELEASE_PUBLISH" == "true" ]]; then
     # The passphrase reaches the plugin through MAVEN_GPG_PASSPHRASE rather than the
     # command line, where it would be visible to any local user through ps.
     mvn "$MVN_GPG_PLUGIN:sign-and-deploy-file" \
-        -DgroupId=org.apache.toree \
-        -DartifactId=toree-assembly \
-        -Dversion="$RELEASE_VERSION-incubating" \
-        -Dpackaging=jar \
         -Dfile="toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar" \
+        -DpomFile="toree/dist/toree/toree-assembly-$RELEASE_VERSION-incubating.pom" \
         -DrepositoryId=apache.releases.https \
         -Durl=https://repository.apache.org/service/local/staging/deploy/maven2
 


### PR DESCRIPTION
The toree-assembly jar was deployed to Maven via
gpg:sign-and-deploy-file without a POM file, causing Maven to
generate a minimal POM missing the license and Incubator
disclaimer required by Apache policy.

- Add POM template with license, description, parent, URL, SCM
- Generate versioned POM during make dist from template
- Pass -DpomFile to mvn deploy in the release script
- Add description to build.sbt, read from DISCLAIMER
- Fix license name from "Apache 2" to "Apache License, Version 2.0"
- Record the change in RELEASE_NOTES.md
