### PR TITLE
Revert "Bump sbt/setup-sbt from 1.1.22 to 1.2.1 (#261)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         java-version: ${{ matrix.java }}
         cache: sbt
     - name: Install sbt
-      uses: sbt/setup-sbt@af116cce31c00823d3903ce687f9cda3a4f19f1b # v1.2.1
+      uses: sbt/setup-sbt@508b753e53cb6095967669e0911487d2b9bc9f41 # v1.1.22
     - name: Build
       run: |
         make SCALA_VERSION=${{ matrix.scala }} clean release


### PR DESCRIPTION
This reverts commit bfbb2ef39f579c9647cf1bc62fe23953654e8b6a.

Since v1.1.23, sbt/setup-sbt is a composite action that internally uses carabiner-dev/actions/ampel/verify to check the signature of the downloaded sbt distribution. The ASF org policy only permits actions authored by GitHub, owned by the enterprise, or explicitly allowlisted, so every build fails before it starts with:

  action carabiner-dev/actions/ampel/verify is not allowed in apache

The nested step is configured with fail: false (monitor only), but that does not help: GitHub rejects the action while loading the workflow, before any step runs.

v1.1.22 is the last release without that dependency, so pin back to it until carabiner-dev/actions is allowlisted by ASF INFRA or setup-sbt drops the nested action.