### PR TITLE
Pass the GPG passphrase through the environment

### DIFF
--- a/etc/tools/release-build.sh
+++ b/etc/tools/release-build.sh
@@ -50,7 +50,7 @@ OPTIONS
 
 A GPG passphrase is expected as an environment variable
 
-GPG_PASSPHRASE - Passphrase for GPG key used to sign release
+MAVEN_GPG_PASSPHRASE - Passphrase for GPG key used to sign release
 
 EXAMPLES
 
@@ -136,12 +136,21 @@ while [ "${1+defined}" ]; do
 done
 
 
-if [[ -z "$GPG_PASSPHRASE" ]]; then
-    echo 'The environment variable GPG_PASSPHRASE is not set. Enter the passphrase to'
+# Pinned so the release is reproducible and so passphraseEnvName (3.2.0+) is available.
+MVN_GPG_PLUGIN="org.apache.maven.plugins:maven-gpg-plugin:3.2.8"
+
+if [[ -z "$MAVEN_GPG_PASSPHRASE" ]]; then
+    echo 'The environment variable MAVEN_GPG_PASSPHRASE is not set. Enter the passphrase to'
     echo 'unlock the GPG signing key that will be used to sign the release!'
     echo
-    stty -echo && printf "GPG passphrase: " && read GPG_PASSPHRASE && printf '\n' && stty echo
-  fi
+    stty -echo && printf "GPG passphrase: " && read MAVEN_GPG_PASSPHRASE && printf '\n' && stty echo
+fi
+# maven-gpg-plugin reads the passphrase from this variable, so it must be exported
+# for the deploy commands below; a value inherited from the caller already is.
+# MAVEN_GPG_PASSPHRASE is the plugin's default passphraseEnvName, so no extra
+# configuration is needed to point it here. See:
+# https://github.com/apache/maven-gpg-plugin/blob/76316ce61699afaec7a298fd279e1c9133c38ac6/src/main/java/org/apache/maven/plugins/gpg/AbstractGpgMojo.java#L45
+export MAVEN_GPG_PASSPHRASE
 
 if [[ "$RELEASE_PREPARE" == "true" && -z "$RELEASE_VERSION" ]]; then
     echo "ERROR: --releaseVersion must be passed as an argument to run this script"
@@ -295,7 +304,16 @@ if [[ "$RELEASE_PREPARE" == "true" ]]; then
         svn ci -m"Apache Toree $RELEASE_STAGING_FOLDER"
 
         cd "$BASE_DIR/target"
-        mvn gpg:sign-and-deploy-file -DgroupId=org.apache.toree -DartifactId=toree-assembly -Dversion=$RELEASE_VERSION-incubating -Dpackaging=jar -Dfile=toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar -DrepositoryId=apache.releases.https -Durl=https://repository.apache.org/service/local/staging/deploy/maven2 -Dpassphrase=$GPG_PASSPHRASE
+        # The passphrase reaches the plugin through MAVEN_GPG_PASSPHRASE rather than the
+        # command line, where it would be visible to any local user through ps.
+        mvn "$MVN_GPG_PLUGIN:sign-and-deploy-file" \
+            -DgroupId=org.apache.toree \
+            -DartifactId=toree-assembly \
+            -Dversion="$RELEASE_VERSION-incubating" \
+            -Dpackaging=jar \
+            -Dfile="toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar" \
+            -DrepositoryId=apache.releases.https \
+            -Durl=https://repository.apache.org/service/local/staging/deploy/maven2
     fi
 
     cd "$BASE_DIR" #exit target
@@ -314,7 +332,16 @@ if [[ "$RELEASE_PUBLISH" == "true" ]]; then
     make clean dist release
 
     cd "$BASE_DIR/target"
-    mvn gpg:sign-and-deploy-file -DgroupId=org.apache.toree -DartifactId=toree-assembly -Dversion=$RELEASE_VERSION-incubating -Dpackaging=jar -Dfile=toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar -DrepositoryId=apache.releases.https -Durl=https://repository.apache.org/service/local/staging/deploy/maven2 -Dpassphrase=$GPG_PASSPHRASE
+    # The passphrase reaches the plugin through MAVEN_GPG_PASSPHRASE rather than the
+    # command line, where it would be visible to any local user through ps.
+    mvn "$MVN_GPG_PLUGIN:sign-and-deploy-file" \
+        -DgroupId=org.apache.toree \
+        -DartifactId=toree-assembly \
+        -Dversion="$RELEASE_VERSION-incubating" \
+        -Dpackaging=jar \
+        -Dfile="toree/dist/toree/lib/toree-assembly-$RELEASE_VERSION-incubating.jar" \
+        -DrepositoryId=apache.releases.https \
+        -Durl=https://repository.apache.org/service/local/staging/deploy/maven2
 
     cd "$BASE_DIR" #exit target
 


### PR DESCRIPTION
The release script passed the signing passphrase as

The -Dpassphrase never reached maven-gpg-plugin: the parameter's expression
is ${gpg.passphrase}, and it has no alias, so the system property named
"passphrase" was silently ignored and signing fell back to gpg-agent.
The plugin also deprecates that parameter outright -- "Do not use this
configuration, it may leak sensitive information" -- because anything on
argv is readable by any local user via ps.

Take the passphrase from MAVEN_GPG_PASSPHRASE, the default of the
plugin's passphraseEnvName and the route it documents for batch-mode
signing, and export it once rather than aliasing GPG_PASSPHRASE at each
call site. This renames the script's own input variable, so a release
environment exporting GPG_PASSPHRASE will now be prompted instead.

Pin the plugin version while here: an unversioned prefix resolves to
whatever is latest at release time, and passphraseEnvName only exists
from 3.2.0 onward.

### Behaviour change for release managers

MAVEN_GPG_PASSPHRASE replaces GPG_PASSPHRASE as the variable the script
reads. An environment that exports GPG_PASSPHRASE will now fall through
to the interactive prompt rather than picking it up. It fails safe -- a
prompt, never a bad signature -- but it is silent, so release
environments should be updated before the next release.

Exporting the variable also means it is inherited by the script's child
processes rather than being scoped to the two `mvn` calls. That matches
what already happens whenever the variable is set in the caller's
environment.

### Verification

Tested against a throwaway keyring with the agent cache disabled
(`default-cache-ttl 0`, `max-cache-ttl 0`) and the agent killed between
runs, deploying to a `file://` repository:

| passphrase supplied as | result |
| --- | --- |
| nothing (control) | fails, `gpg: signing failed: No pinentry` |
| `-Dpassphrase` | fails identically to the control |
| `MAVEN_GPG_PASSPHRASE` exported | succeeds, good signatures on jar and POM |

Signatures were checked with `gpg --verify`, not merely counted. The
interactive path was confirmed separately: a value read at the prompt is
exported and visible to child processes, which is what the removed
per-call prefix used to guarantee. Also confirmed the plugin does not
require `allow-loopback-pinentry` on the release host with GnuPG 2.2.
